### PR TITLE
Add /ping endpoint for lightweight health checks

### DIFF
--- a/src/Controller/PingController.php
+++ b/src/Controller/PingController.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kiora\HealthCheckBundle\Controller;
+
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\Routing\Attribute\Route;
+
+/**
+ * Controller providing lightweight ping endpoint for liveness probes.
+ *
+ * This endpoint performs no external service checks and always returns 200,
+ * making it ideal for Kubernetes liveness probes and load balancer health checks.
+ */
+class PingController extends AbstractController
+{
+    /**
+     * Simple ping endpoint to verify the application is running.
+     *
+     * Returns a simple JSON response with status "up" and current timestamp.
+     * Does not perform any database or external service checks.
+     *
+     * @return JsonResponse JSON response with "up" status
+     */
+    #[Route('/ping', name: 'health_ping', methods: ['GET'])]
+    public function ping(): JsonResponse
+    {
+        return new JsonResponse([
+            'status' => 'up',
+            'timestamp' => (new \DateTimeImmutable())->format(\DateTimeInterface::RFC3339),
+        ], 200, [
+            'X-Robots-Tag' => 'noindex, nofollow',
+            'X-Content-Type-Options' => 'nosniff',
+            'Cache-Control' => 'no-store, no-cache, must-revalidate, private',
+        ]);
+    }
+}

--- a/tests/Controller/PingControllerTest.php
+++ b/tests/Controller/PingControllerTest.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kiora\HealthCheckBundle\Tests\Controller;
+
+use Kiora\HealthCheckBundle\Controller\PingController;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\JsonResponse;
+
+/**
+ * Test suite for PingController.
+ */
+class PingControllerTest extends TestCase
+{
+    private PingController $controller;
+
+    protected function setUp(): void
+    {
+        $this->controller = new PingController();
+    }
+
+    public function testPingReturnsUpStatus(): void
+    {
+        $response = $this->controller->ping();
+
+        $this->assertInstanceOf(JsonResponse::class, $response);
+        $this->assertEquals(200, $response->getStatusCode());
+
+        $data = json_decode($response->getContent(), true);
+        $this->assertIsArray($data);
+        $this->assertEquals('up', $data['status']);
+        $this->assertArrayHasKey('timestamp', $data);
+    }
+
+    public function testPingReturnsValidTimestamp(): void
+    {
+        $response = $this->controller->ping();
+        $data = json_decode($response->getContent(), true);
+
+        // Verify timestamp is in RFC3339 format
+        $this->assertNotEmpty($data['timestamp']);
+        $timestamp = \DateTimeImmutable::createFromFormat(\DateTimeInterface::RFC3339, $data['timestamp']);
+        $this->assertInstanceOf(\DateTimeImmutable::class, $timestamp);
+    }
+
+    public function testPingReturnsSecurityHeaders(): void
+    {
+        $response = $this->controller->ping();
+
+        $this->assertEquals('noindex, nofollow', $response->headers->get('X-Robots-Tag'));
+        $this->assertEquals('nosniff', $response->headers->get('X-Content-Type-Options'));
+        $this->assertEquals('no-store, no-cache, must-revalidate, private', $response->headers->get('Cache-Control'));
+    }
+
+    public function testPingDoesNotRequireExternalDependencies(): void
+    {
+        // The controller should work without any constructor dependencies
+        $controller = new PingController();
+        $response = $controller->ping();
+
+        $this->assertInstanceOf(JsonResponse::class, $response);
+        $this->assertEquals(200, $response->getStatusCode());
+    }
+}


### PR DESCRIPTION
## Description
Add a simple `/ping` endpoint for ultra-lightweight health checks, perfect for Kubernetes liveness probes and load balancers.

## Changes
- ✅ Created `PingController` with `/ping` route
- ✅ Returns simple JSON: `{"status": "up", "timestamp": "..."}`
- ✅ No database or external service checks
- ✅ Always returns HTTP 200
- ✅ Includes security headers (X-Robots-Tag, X-Content-Type-Options, Cache-Control)
- ✅ Comprehensive test coverage with 4 test cases

## Benefits
- Reduce load on database from frequent health checks
- Faster response time (no I/O operations)
- Better separation of concerns (liveness vs readiness)
- Ideal for high-frequency polling

## Testing
```bash
curl http://localhost/ping
# Response: {"status":"up","timestamp":"2025-11-15T..."}
```

## Related Issue
Fixes #1