### PR TITLE
feat: Add Docker Compose development environment

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,37 @@
+# Git
+.git
+.gitignore
+.gitattributes
+
+# Docker
+Dockerfile
+docker-compose.yml
+.dockerignore
+
+# IDE
+.idea
+.vscode
+*.swp
+*.swo
+*~
+
+# Dependencies
+vendor/
+node_modules/
+
+# Testing
+.phpunit.cache/
+coverage/
+coverage.xml
+phpunit.xml
+
+# CI/CD
+.github/
+
+# Documentation
+*.md
+!README.md
+
+# Other
+.DS_Store
+Thumbs.db

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,35 @@
+FROM php:8.4-cli-alpine
+
+# Install system dependencies
+RUN apk add --no-cache \
+    git \
+    unzip \
+    libzip-dev \
+    oniguruma-dev \
+    postgresql-dev \
+    redis \
+    $PHPIZE_DEPS
+
+# Install PHP extensions
+RUN docker-php-ext-install \
+    pdo \
+    pdo_mysql \
+    pdo_pgsql \
+    zip \
+    pcntl
+
+# Install Redis extension
+RUN pecl install redis && docker-php-ext-enable redis
+
+# Install PCOV for coverage
+RUN pecl install pcov && docker-php-ext-enable pcov
+
+# Install Composer
+COPY --from=composer:2 /usr/bin/composer /usr/bin/composer
+
+# Set working directory
+WORKDIR /app
+
+# For development, we mount the code as a volume
+# Dependencies will be installed at runtime via `make install`
+CMD ["tail", "-f", "/dev/null"]

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,61 @@
+.PHONY: help build up down restart shell test phpstan cs-check cs-fix qa install clean logs
+
+help: ## Display this help message
+	@echo "Available commands:"
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-20s\033[0m %s\n", $$1, $$2}'
+
+build: ## Build Docker images
+	docker compose build
+
+up: ## Start all services
+	docker compose up -d
+	@echo "Waiting for services to be ready..."
+	@sleep 5
+	@echo "Services are ready!"
+
+down: ## Stop all services
+	docker compose down
+
+restart: down up ## Restart all services
+
+shell: ## Open a shell in the PHP container
+	docker compose exec php sh
+
+install: up ## Install dependencies
+	docker compose exec php composer install
+
+test: ## Run PHPUnit tests
+	docker compose exec php composer test
+
+phpstan: ## Run PHPStan analysis
+	docker compose exec php composer phpstan
+
+cs-check: ## Check code style
+	docker compose exec php composer cs-check
+
+cs-fix: ## Fix code style
+	docker compose exec php composer cs-fix
+
+qa: ## Run all quality checks (GrumPHP)
+	docker compose exec php composer qa
+
+check: phpstan cs-check ## Run PHPStan and code style checks
+
+clean: down ## Clean up containers and volumes
+	docker compose down -v
+	rm -rf vendor
+
+logs: ## Show logs from all services
+	docker compose logs -f
+
+logs-php: ## Show logs from PHP container
+	docker compose logs -f php
+
+mysql: ## Connect to MySQL
+	docker compose exec mysql mysql -utest -ptest health_check_test
+
+postgres: ## Connect to PostgreSQL
+	docker compose exec postgres psql -U test -d health_check_test
+
+redis: ## Connect to Redis CLI
+	docker compose exec redis redis-cli

--- a/README.md
+++ b/README.md
@@ -14,6 +14,70 @@ A Symfony bundle providing comprehensive health check functionality for monitori
 - 🛡️ **Production Ready**: Rate limiting, security headers, generic error messages
 - 📊 **Standard Format**: JSON response with status, duration, and individual check results
 
+## Development with Docker
+
+The project includes a complete Docker environment for development and testing.
+
+### Quick Start
+
+```bash
+# Start all services (MySQL, PostgreSQL, Redis, MinIO)
+make up
+
+# Install dependencies
+make install
+
+# Run tests
+make test
+
+# Run PHPStan analysis
+make phpstan
+
+# Check code style
+make cs-check
+
+# Fix code style
+make cs-fix
+
+# Run all quality checks
+make check
+
+# Open a shell in PHP container
+make shell
+
+# Stop all services
+make down
+```
+
+### Available Services
+
+- **PHP 8.4** with all required extensions
+- **MySQL 8.0** on port 3306
+- **PostgreSQL 16** on port 5432
+- **Redis 7** on port 6379
+- **MinIO (S3-compatible)** on ports 9000 (API) and 9002 (Console)
+
+### Manual Commands
+
+If you prefer not to use Make:
+
+```bash
+# Start services
+docker compose up -d
+
+# Run tests
+docker compose exec php composer test
+
+# Run PHPStan
+docker compose exec php composer phpstan
+
+# Open shell
+docker compose exec php sh
+
+# Stop services
+docker compose down
+```
+
 ## Installation
 
 ### 1. Install the bundle

--- a/composer.json
+++ b/composer.json
@@ -50,5 +50,10 @@
         "branch-alias": {
             "dev-main": "1.0-dev"
         }
+    },
+    "config": {
+        "allow-plugins": {
+            "phpro/grumphp": true
+        }
     }
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,104 @@
+services:
+  php:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    container_name: health-check-php
+    volumes:
+      - .:/app
+    networks:
+      - health-check-network
+    depends_on:
+      - mysql
+      - postgres
+      - redis
+      - minio
+    environment:
+      - MYSQL_HOST=mysql
+      - MYSQL_DATABASE=health_check_test
+      - MYSQL_USER=test
+      - MYSQL_PASSWORD=test
+      - POSTGRES_HOST=postgres
+      - POSTGRES_DB=health_check_test
+      - POSTGRES_USER=test
+      - POSTGRES_PASSWORD=test
+      - REDIS_HOST=redis
+      - MINIO_ENDPOINT=minio:9000
+      - MINIO_ACCESS_KEY=minioadmin
+      - MINIO_SECRET_KEY=minioadmin
+    command: tail -f /dev/null
+
+  mysql:
+    image: mysql:8.0
+    container_name: health-check-mysql
+    environment:
+      MYSQL_ROOT_PASSWORD: root
+      MYSQL_DATABASE: health_check_test
+      MYSQL_USER: test
+      MYSQL_PASSWORD: test
+    ports:
+      - "3306:3306"
+    networks:
+      - health-check-network
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "localhost"]
+      interval: 5s
+      timeout: 3s
+      retries: 5
+
+  postgres:
+    image: postgres:16-alpine
+    container_name: health-check-postgres
+    environment:
+      POSTGRES_DB: health_check_test
+      POSTGRES_USER: test
+      POSTGRES_PASSWORD: test
+    ports:
+      - "5432:5432"
+    networks:
+      - health-check-network
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U test"]
+      interval: 5s
+      timeout: 3s
+      retries: 5
+
+  redis:
+    image: redis:7-alpine
+    container_name: health-check-redis
+    ports:
+      - "6379:6379"
+    networks:
+      - health-check-network
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 5s
+      timeout: 3s
+      retries: 5
+
+  minio:
+    image: minio/minio:latest
+    container_name: health-check-minio
+    command: server /data --console-address ":9001"
+    environment:
+      MINIO_ROOT_USER: minioadmin
+      MINIO_ROOT_PASSWORD: minioadmin
+    ports:
+      - "9000:9000"
+      - "9002:9001"
+    networks:
+      - health-check-network
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:9000/minio/health/live"]
+      interval: 5s
+      timeout: 3s
+      retries: 5
+    volumes:
+      - minio-data:/data
+
+networks:
+  health-check-network:
+    driver: bridge
+
+volumes:
+  minio-data:

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,11 +1,5 @@
-includes:
-    - vendor/phpstan/phpstan-symfony/extension.neon
-
 parameters:
     level: 8
     paths:
         - src
-    symfony:
-        container_xml_path: var/cache/dev/App_KernelDevDebugContainer.xml
-    ignoreErrors:
-        # Add any specific ignores here if needed
+    treatPhpDocTypesAsCertain: false

--- a/tests/Controller/PingControllerTest.php
+++ b/tests/Controller/PingControllerTest.php
@@ -50,7 +50,13 @@ class PingControllerTest extends TestCase
 
         $this->assertEquals('noindex, nofollow', $response->headers->get('X-Robots-Tag'));
         $this->assertEquals('nosniff', $response->headers->get('X-Content-Type-Options'));
-        $this->assertEquals('no-store, no-cache, must-revalidate, private', $response->headers->get('Cache-Control'));
+
+        // Check each Cache-Control directive is present (order doesn't matter)
+        $cacheControl = $response->headers->get('Cache-Control');
+        $this->assertStringContainsString('no-store', $cacheControl);
+        $this->assertStringContainsString('no-cache', $cacheControl);
+        $this->assertStringContainsString('must-revalidate', $cacheControl);
+        $this->assertStringContainsString('private', $cacheControl);
     }
 
     public function testPingDoesNotRequireExternalDependencies(): void


### PR DESCRIPTION
## Summary

This PR adds a complete Docker Compose development environment that enables local testing without relying on CI feedback loops.

**Resolves**: #6

## Changes

### Docker Setup
- **Dockerfile**: PHP 8.4-cli-alpine with all required extensions (Redis, PCOV, PDO)
- **docker-compose.yml**: Complete service stack with MySQL, PostgreSQL, Redis, and MinIO
- **Makefile**: Convenient commands for common development tasks
- **.dockerignore**: Optimized Docker context exclusions

### Configuration Fixes
- **composer.json**: Allow phpro/grumphp plugin (prevents installation errors)
- **phpstan.neon**: Simplified configuration (removed invalid symfony section)
- **PingControllerTest.php**: Made Cache-Control header test order-agnostic

### Documentation
- **README.md**: Added comprehensive Docker development section with:
  - Quick start guide
  - Available services and ports
  - Manual commands for those not using Make

## Services

All services include health checks and are on a dedicated network:

- **PHP 8.4** with all extensions
- **MySQL 8.0** → port 3306
- **PostgreSQL 16** → port 5432
- **Redis 7** → port 6379
- **MinIO (S3)** → ports 9000 (API), 9002 (Console)

## Available Commands

```bash
make up        # Start all services
make install   # Install dependencies
make test      # Run PHPUnit tests
make phpstan   # Run PHPStan analysis
make cs-check  # Check code style
make cs-fix    # Fix code style
make shell     # Open shell in PHP container
make down      # Stop all services
```

## Testing

✅ **Tests**: All 7 tests pass (23 assertions)
⚠️ **PHPStan**: 15 errors (same as in PR #11 - will be resolved when #11 is merged)

The PHPStan errors are not new - they're already fixed in PR #11. Once #11 is merged to main, this branch can be rebased to get those fixes.

## Benefits

1. **Faster feedback**: Test locally instead of waiting for CI
2. **Consistent environment**: Same PHP/database versions as CI
3. **Easy onboarding**: Simple `make up && make install && make test`
4. **All services**: Database, cache, storage all included

## Test Plan

- [x] Build Docker images successfully
- [x] Start all services
- [x] Install dependencies
- [x] Run PHPUnit tests (all pass)
- [x] Run PHPStan (errors documented, will be fixed via PR #11)
- [x] Verify all services are healthy