### PR TITLE
Refactor: Add factory methods to AbstractHealthCheck to reduce duplication

### DIFF
--- a/src/HealthCheck/AbstractHealthCheck.php
+++ b/src/HealthCheck/AbstractHealthCheck.php
@@ -80,4 +80,64 @@ abstract class AbstractHealthCheck implements HealthCheckInterface
      * in the returned result.
      */
     abstract protected function doCheck(): HealthCheckResult;
+
+    /**
+     * Create a healthy result.
+     *
+     * Factory method to reduce code duplication when creating healthy results.
+     * Duration will be automatically calculated by check(), so it's set to 0.0.
+     *
+     * @param string               $message  Human-readable success message
+     * @param array<string, mixed> $metadata Additional contextual information
+     */
+    protected function createHealthyResult(string $message, array $metadata = []): HealthCheckResult
+    {
+        return new HealthCheckResult(
+            name: $this->getName(),
+            status: HealthCheckStatus::HEALTHY,
+            message: $message,
+            duration: 0.0,
+            metadata: $metadata
+        );
+    }
+
+    /**
+     * Create an unhealthy result.
+     *
+     * Factory method to reduce code duplication when creating unhealthy results.
+     * Duration will be automatically calculated by check(), so it's set to 0.0.
+     *
+     * @param string               $message  Human-readable error message
+     * @param array<string, mixed> $metadata Additional contextual information
+     */
+    protected function createUnhealthyResult(string $message, array $metadata = []): HealthCheckResult
+    {
+        return new HealthCheckResult(
+            name: $this->getName(),
+            status: HealthCheckStatus::UNHEALTHY,
+            message: $message,
+            duration: 0.0,
+            metadata: $metadata
+        );
+    }
+
+    /**
+     * Create a degraded result.
+     *
+     * Factory method to reduce code duplication when creating degraded results.
+     * Duration will be automatically calculated by check(), so it's set to 0.0.
+     *
+     * @param string               $message  Human-readable warning message
+     * @param array<string, mixed> $metadata Additional contextual information
+     */
+    protected function createDegradedResult(string $message, array $metadata = []): HealthCheckResult
+    {
+        return new HealthCheckResult(
+            name: $this->getName(),
+            status: HealthCheckStatus::DEGRADED,
+            message: $message,
+            duration: 0.0,
+            metadata: $metadata
+        );
+    }
 }

--- a/src/HealthCheck/Checks/DatabaseHealthCheck.php
+++ b/src/HealthCheck/Checks/DatabaseHealthCheck.php
@@ -7,7 +7,6 @@ namespace Kiora\HealthCheckBundle\HealthCheck\Checks;
 use Doctrine\DBAL\Connection;
 use Kiora\HealthCheckBundle\HealthCheck\AbstractHealthCheck;
 use Kiora\HealthCheckBundle\HealthCheck\HealthCheckResult;
-use Kiora\HealthCheckBundle\HealthCheck\HealthCheckStatus;
 
 /**
  * Health check for database connectivity using Doctrine DBAL.
@@ -62,30 +61,12 @@ class DatabaseHealthCheck extends AbstractHealthCheck
             $result = $this->connection->fetchOne('SELECT 1');
 
             if (1 !== $result && '1' !== $result) {
-                return new HealthCheckResult(
-                    name: $this->getName(),
-                    status: HealthCheckStatus::UNHEALTHY,
-                    message: 'Database query failed',
-                    duration: 0.0,
-                    metadata: []
-                );
+                return $this->createUnhealthyResult('Database query failed');
             }
 
-            return new HealthCheckResult(
-                name: $this->getName(),
-                status: HealthCheckStatus::HEALTHY,
-                message: 'Database operational',
-                duration: 0.0,
-                metadata: []
-            );
+            return $this->createHealthyResult('Database operational');
         } catch (\Exception $e) {
-            return new HealthCheckResult(
-                name: $this->getName(),
-                status: HealthCheckStatus::UNHEALTHY,
-                message: 'Database connection failed',
-                duration: 0.0,
-                metadata: []
-            );
+            return $this->createUnhealthyResult('Database connection failed');
         }
     }
 }

--- a/src/HealthCheck/Checks/HttpHealthCheck.php
+++ b/src/HealthCheck/Checks/HttpHealthCheck.php
@@ -6,7 +6,6 @@ namespace Kiora\HealthCheckBundle\HealthCheck\Checks;
 
 use Kiora\HealthCheckBundle\HealthCheck\AbstractHealthCheck;
 use Kiora\HealthCheckBundle\HealthCheck\HealthCheckResult;
-use Kiora\HealthCheckBundle\HealthCheck\HealthCheckStatus;
 
 /**
  * Health check for HTTP endpoints.
@@ -72,13 +71,7 @@ class HttpHealthCheck extends AbstractHealthCheck
             $response = @file_get_contents($this->url, false, $context);
 
             if (false === $response) {
-                return new HealthCheckResult(
-                    name: $this->getName(),
-                    status: HealthCheckStatus::UNHEALTHY,
-                    message: 'HTTP endpoint unreachable',
-                    duration: 0.0,
-                    metadata: []
-                );
+                return $this->createUnhealthyResult('HTTP endpoint unreachable');
             }
 
             // Parse HTTP response code
@@ -91,30 +84,12 @@ class HttpHealthCheck extends AbstractHealthCheck
 
             // Check if status code is expected
             if (!in_array($statusCode, $this->expectedStatusCodes, true)) {
-                return new HealthCheckResult(
-                    name: $this->getName(),
-                    status: HealthCheckStatus::UNHEALTHY,
-                    message: 'HTTP endpoint returned unexpected status',
-                    duration: 0.0,
-                    metadata: []
-                );
+                return $this->createUnhealthyResult('HTTP endpoint returned unexpected status');
             }
 
-            return new HealthCheckResult(
-                name: $this->getName(),
-                status: HealthCheckStatus::HEALTHY,
-                message: 'HTTP endpoint operational',
-                duration: 0.0,
-                metadata: []
-            );
+            return $this->createHealthyResult('HTTP endpoint operational');
         } catch (\Exception $e) {
-            return new HealthCheckResult(
-                name: $this->getName(),
-                status: HealthCheckStatus::UNHEALTHY,
-                message: 'HTTP check failed',
-                duration: 0.0,
-                metadata: []
-            );
+            return $this->createUnhealthyResult('HTTP check failed');
         }
     }
 }

--- a/src/HealthCheck/Checks/RedisHealthCheck.php
+++ b/src/HealthCheck/Checks/RedisHealthCheck.php
@@ -6,7 +6,6 @@ namespace Kiora\HealthCheckBundle\HealthCheck\Checks;
 
 use Kiora\HealthCheckBundle\HealthCheck\AbstractHealthCheck;
 use Kiora\HealthCheckBundle\HealthCheck\HealthCheckResult;
-use Kiora\HealthCheckBundle\HealthCheck\HealthCheckStatus;
 
 /**
  * Health check for Redis connectivity.
@@ -62,13 +61,7 @@ class RedisHealthCheck extends AbstractHealthCheck
             $connected = @$redis->connect($this->host, $this->port, 2);
 
             if (!$connected) {
-                return new HealthCheckResult(
-                    name: $this->getName(),
-                    status: HealthCheckStatus::UNHEALTHY,
-                    message: 'Redis connection failed',
-                    duration: 0.0,
-                    metadata: []
-                );
+                return $this->createUnhealthyResult('Redis connection failed');
             }
 
             // Send PING command to Redis
@@ -81,30 +74,12 @@ class RedisHealthCheck extends AbstractHealthCheck
                 || 'PONG' === $response;
 
             if (!$isPongValid) {
-                return new HealthCheckResult(
-                    name: $this->getName(),
-                    status: HealthCheckStatus::UNHEALTHY,
-                    message: 'Redis ping failed',
-                    duration: 0.0,
-                    metadata: []
-                );
+                return $this->createUnhealthyResult('Redis ping failed');
             }
 
-            return new HealthCheckResult(
-                name: $this->getName(),
-                status: HealthCheckStatus::HEALTHY,
-                message: 'Redis operational',
-                duration: 0.0,
-                metadata: []
-            );
+            return $this->createHealthyResult('Redis operational');
         } catch (\Exception $e) {
-            return new HealthCheckResult(
-                name: $this->getName(),
-                status: HealthCheckStatus::UNHEALTHY,
-                message: 'Redis connection failed',
-                duration: 0.0,
-                metadata: []
-            );
+            return $this->createUnhealthyResult('Redis connection failed');
         } finally {
             // Close Redis connection if it was established
             if ($redis instanceof \Redis) {

--- a/src/HealthCheck/Checks/S3HealthCheck.php
+++ b/src/HealthCheck/Checks/S3HealthCheck.php
@@ -6,7 +6,6 @@ namespace Kiora\HealthCheckBundle\HealthCheck\Checks;
 
 use Kiora\HealthCheckBundle\HealthCheck\AbstractHealthCheck;
 use Kiora\HealthCheckBundle\HealthCheck\HealthCheckResult;
-use Kiora\HealthCheckBundle\HealthCheck\HealthCheckStatus;
 use League\Flysystem\FilesystemOperator;
 
 /**
@@ -59,21 +58,9 @@ class S3HealthCheck extends AbstractHealthCheck
             // Try to list files (limit to 1) to verify bucket access
             $this->filesystem->listContents('/', false)->toArray();
 
-            return new HealthCheckResult(
-                name: $this->getName(),
-                status: HealthCheckStatus::HEALTHY,
-                message: 'S3 storage operational',
-                duration: 0.0,
-                metadata: []
-            );
+            return $this->createHealthyResult('S3 storage operational');
         } catch (\Exception $e) {
-            return new HealthCheckResult(
-                name: $this->getName(),
-                status: HealthCheckStatus::UNHEALTHY,
-                message: 'S3 storage connection failed',
-                duration: 0.0,
-                metadata: []
-            );
+            return $this->createUnhealthyResult('S3 storage connection failed');
         }
     }
 }

--- a/tests/HealthCheck/AbstractHealthCheckTest.php
+++ b/tests/HealthCheck/AbstractHealthCheckTest.php
@@ -1,0 +1,150 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kiora\HealthCheckBundle\Tests\HealthCheck;
+
+use Kiora\HealthCheckBundle\HealthCheck\AbstractHealthCheck;
+use Kiora\HealthCheckBundle\HealthCheck\HealthCheckResult;
+use Kiora\HealthCheckBundle\HealthCheck\HealthCheckStatus;
+use PHPUnit\Framework\TestCase;
+
+class AbstractHealthCheckTest extends TestCase
+{
+    private ConcreteHealthCheck $healthCheck;
+
+    protected function setUp(): void
+    {
+        $this->healthCheck = new ConcreteHealthCheck();
+    }
+
+    public function testCreateHealthyResult(): void
+    {
+        $result = $this->healthCheck->testCreateHealthyResult('All systems operational');
+
+        $this->assertInstanceOf(HealthCheckResult::class, $result);
+        $this->assertSame('test_check', $result->name);
+        $this->assertSame(HealthCheckStatus::HEALTHY, $result->status);
+        $this->assertSame('All systems operational', $result->message);
+        $this->assertSame(0.0, $result->duration);
+        $this->assertSame([], $result->metadata);
+    }
+
+    public function testCreateHealthyResultWithMetadata(): void
+    {
+        $metadata = ['version' => '1.0', 'uptime' => 3600];
+        $result = $this->healthCheck->testCreateHealthyResult('Service running', $metadata);
+
+        $this->assertSame(HealthCheckStatus::HEALTHY, $result->status);
+        $this->assertSame('Service running', $result->message);
+        $this->assertSame($metadata, $result->metadata);
+    }
+
+    public function testCreateUnhealthyResult(): void
+    {
+        $result = $this->healthCheck->testCreateUnhealthyResult('Service unavailable');
+
+        $this->assertInstanceOf(HealthCheckResult::class, $result);
+        $this->assertSame('test_check', $result->name);
+        $this->assertSame(HealthCheckStatus::UNHEALTHY, $result->status);
+        $this->assertSame('Service unavailable', $result->message);
+        $this->assertSame(0.0, $result->duration);
+        $this->assertSame([], $result->metadata);
+    }
+
+    public function testCreateUnhealthyResultWithMetadata(): void
+    {
+        $metadata = ['error_code' => 500, 'retry_after' => 60];
+        $result = $this->healthCheck->testCreateUnhealthyResult('Connection failed', $metadata);
+
+        $this->assertSame(HealthCheckStatus::UNHEALTHY, $result->status);
+        $this->assertSame('Connection failed', $result->message);
+        $this->assertSame($metadata, $result->metadata);
+    }
+
+    public function testCreateDegradedResult(): void
+    {
+        $result = $this->healthCheck->testCreateDegradedResult('Slow response time');
+
+        $this->assertInstanceOf(HealthCheckResult::class, $result);
+        $this->assertSame('test_check', $result->name);
+        $this->assertSame(HealthCheckStatus::DEGRADED, $result->status);
+        $this->assertSame('Slow response time', $result->message);
+        $this->assertSame(0.0, $result->duration);
+        $this->assertSame([], $result->metadata);
+    }
+
+    public function testCreateDegradedResultWithMetadata(): void
+    {
+        $metadata = ['latency' => 250, 'threshold' => 100];
+        $result = $this->healthCheck->testCreateDegradedResult('Performance degraded', $metadata);
+
+        $this->assertSame(HealthCheckStatus::DEGRADED, $result->status);
+        $this->assertSame('Performance degraded', $result->message);
+        $this->assertSame($metadata, $result->metadata);
+    }
+
+    public function testFactoryMethodsUseName(): void
+    {
+        $healthy = $this->healthCheck->testCreateHealthyResult('OK');
+        $unhealthy = $this->healthCheck->testCreateUnhealthyResult('Failed');
+        $degraded = $this->healthCheck->testCreateDegradedResult('Slow');
+
+        $this->assertSame('test_check', $healthy->name);
+        $this->assertSame('test_check', $unhealthy->name);
+        $this->assertSame('test_check', $degraded->name);
+    }
+
+    public function testFactoryMethodsSetDurationToZero(): void
+    {
+        $healthy = $this->healthCheck->testCreateHealthyResult('OK');
+        $unhealthy = $this->healthCheck->testCreateUnhealthyResult('Failed');
+        $degraded = $this->healthCheck->testCreateDegradedResult('Slow');
+
+        $this->assertSame(0.0, $healthy->duration);
+        $this->assertSame(0.0, $unhealthy->duration);
+        $this->assertSame(0.0, $degraded->duration);
+    }
+}
+
+/**
+ * Concrete implementation of AbstractHealthCheck for testing purposes.
+ */
+class ConcreteHealthCheck extends AbstractHealthCheck
+{
+    public function getName(): string
+    {
+        return 'test_check';
+    }
+
+    public function getTimeout(): int
+    {
+        return 5;
+    }
+
+    public function isCritical(): bool
+    {
+        return false;
+    }
+
+    protected function doCheck(): HealthCheckResult
+    {
+        return $this->createHealthyResult('Test implementation');
+    }
+
+    // Public wrapper methods to test protected factory methods
+    public function testCreateHealthyResult(string $message, array $metadata = []): HealthCheckResult
+    {
+        return $this->createHealthyResult($message, $metadata);
+    }
+
+    public function testCreateUnhealthyResult(string $message, array $metadata = []): HealthCheckResult
+    {
+        return $this->createUnhealthyResult($message, $metadata);
+    }
+
+    public function testCreateDegradedResult(string $message, array $metadata = []): HealthCheckResult
+    {
+        return $this->createDegradedResult($message, $metadata);
+    }
+}


### PR DESCRIPTION
## Description

Fixes #14

This PR adds factory methods to `AbstractHealthCheck` to eliminate repetitive `HealthCheckResult` instantiation code across all health check implementations.

## Problem

Every health check contained repetitive boilerplate code for creating results:

```php
// Repeated 5+ times per health check
return new HealthCheckResult(
    name: $this->getName(),
    status: HealthCheckStatus::UNHEALTHY,
    message: 'XXX connection failed',
    duration: 0.0,
    metadata: []
);
```

This caused:
- 📋 Code duplication across all health checks
- 🔧 Harder to maintain (changes needed in 4+ places)
- 📖 Less readable code (7 lines for each result)
- 🐛 Potential inconsistencies

## Solution

Added three protected factory methods to `AbstractHealthCheck`:

```php
protected function createHealthyResult(string $message, array $metadata = []): HealthCheckResult
protected function createUnhealthyResult(string $message, array $metadata = []): HealthCheckResult
protected function createDegradedResult(string $message, array $metadata = []): HealthCheckResult
```

## Code Transformation

### Before
```php
return new HealthCheckResult(
    name: $this->getName(),
    status: HealthCheckStatus::UNHEALTHY,
    message: 'Database connection failed',
    duration: 0.0,
    metadata: []
);
```

### After
```php
return $this->createUnhealthyResult('Database connection failed');
```

**Result**: 7 lines → 1 line (86% reduction per usage)

## Changes

### AbstractHealthCheck.php
- ✅ Add `createHealthyResult()` factory method
- ✅ Add `createUnhealthyResult()` factory method
- ✅ Add `createDegradedResult()` factory method
- ✅ Optional metadata parameter for all methods

### Health Check Implementations Updated
- ✅ **DatabaseHealthCheck**: 91 → 72 lines (-21%)
- ✅ **RedisHealthCheck**: 119 → 94 lines (-21%)
- ✅ **S3HealthCheck**: 79 → 66 lines (-16%)
- ✅ **HttpHealthCheck**: 120 → 95 lines (-21%)

### Tests
- ✅ Created `AbstractHealthCheckTest.php` with 8 tests (33 assertions)
- ✅ Test all three factory methods
- ✅ Test with and without metadata
- ✅ Verify correct name, status, duration, and metadata handling

## Impact Metrics

**Code Reduction:**
- Health checks: **-82 lines total**
- Duplication: **~78% reduction** (91 lines → 13 factory calls)

**Benefits:**
- ✨ Single source of truth for result creation
- 📖 Much more readable code
- 🔧 Easier to maintain and extend
- 🎯 Consistent behavior across all checks
- 🏷️ Built-in metadata support

## Quality Assurance

- ✅ **46 tests passing** (138 assertions)
- ✅ **PHPStan Level 9** - no errors
- ✅ **PHP-CS-Fixer** - code style compliant
- ✅ **Backward compatible** - no breaking changes

## Usage Example

```php
// In any health check extending AbstractHealthCheck
public function doCheck(): HealthCheckResult
{
    try {
        // ... perform check ...
        return $this->createHealthyResult('Service operational');
    } catch (\Exception $e) {
        return $this->createUnhealthyResult(
            'Service connection failed',
            ['error' => $e->getMessage()]
        );
    }
}
```

## Testing

Run tests with:
```bash
make test          # All tests
make phpstan       # Static analysis
make cs-fix        # Code style
```