### PR TITLE
feat: Add Symfony 8.0 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,14 +17,14 @@
     },
     "require": {
         "php": ">=8.3",
-        "symfony/framework-bundle": "^6.4|^7.0",
-        "symfony/dependency-injection": "^6.4|^7.0",
-        "symfony/config": "^6.4|^7.0",
-        "symfony/http-kernel": "^6.4|^7.0",
-        "symfony/routing": "^6.4|^7.0"
+        "symfony/framework-bundle": "^6.4|^7.0|^8.0",
+        "symfony/dependency-injection": "^6.4|^7.0|^8.0",
+        "symfony/config": "^6.4|^7.0|^8.0",
+        "symfony/http-kernel": "^6.4|^7.0|^8.0",
+        "symfony/routing": "^6.4|^7.0|^8.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^10.0|^11.0",
+        "phpunit/phpunit": "^10.0|^11.0|^12.0",
         "phpstan/phpstan": "^2.0",
         "phpstan/phpstan-symfony": "^2.0",
         "friendsofphp/php-cs-fixer": "^3.0",
@@ -57,7 +57,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-main": "1.0-dev"
+            "dev-main": "2.0-dev"
         }
     }
 }


### PR DESCRIPTION
## Summary

Ajoute le support de Symfony 8.0 au bundle pour permettre la migration du projet `transfert`.

## Changements

- **Symfony constraints** : `^6.4|^7.0` → `^6.4|^7.0|^8.0`
- **PHPUnit** : Ajout de `^12.0` pour compatibilité Symfony 8.0
- **branch-alias** : `1.0-dev` → `2.0-dev`

## Compatibilité

| Symfony | PHP | Statut |
|---------|-----|--------|
| 6.4 LTS | >=8.2 | ✅ |
| 7.0-7.4 | >=8.2 | ✅ |
| 8.0 | >=8.4 | ✅ **NEW** |

## Contexte

Cette mise à jour est requise pour l'issue [kiora-tech/transfert#5](https://github.com/kiora-tech/transfert/issues/5) - Migration Symfony 7.3 → 8.0.

## Test

Après merge, publier un tag `v2.0.0` pour que le projet transfert puisse utiliser cette version.