### PR TITLE
fix: correct criticality attribution, unreachable probes and check robustness

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,8 +25,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: ['8.3', '8.4']
-        symfony: ['6.4.*', '7.0.*', '7.1.*']
+        php: ['8.3', '8.4', '8.5']
+        # Mirrors the constraints declared in composer.json (^6.4|^7.0|^8.0).
+        symfony: ['6.4.*', '7.4.*', '8.1.*']
+        exclude:
+          # Symfony 8.x requires PHP 8.4 or later.
+          - php: '8.3'
+            symfony: '8.1.*'
 
     steps:
       - name: Checkout code
@@ -48,8 +53,8 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
-          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
-          restore-keys: ${{ runner.os }}-composer-
+          key: ${{ runner.os }}-composer-${{ matrix.php }}-${{ matrix.symfony }}-${{ hashFiles('**/composer.json') }}
+          restore-keys: ${{ runner.os }}-composer-${{ matrix.php }}-
 
       - name: Install dependencies
         run: |
@@ -63,18 +68,59 @@ jobs:
 
       - name: Run tests
         run: composer test
+        env:
+          REDIS_HOST: 127.0.0.1
 
       - name: Run tests with coverage
-        if: matrix.php == '8.4' && matrix.symfony == '7.1.*'
+        if: matrix.php == '8.4' && matrix.symfony == '8.1.*'
         run: vendor/bin/phpunit --coverage-clover=coverage.xml
+        env:
+          REDIS_HOST: 127.0.0.1
 
       - name: Upload coverage to Codecov
-        if: matrix.php == '8.4' && matrix.symfony == '7.1.*'
-        uses: codecov/codecov-action@v4
+        if: matrix.php == '8.4' && matrix.symfony == '8.1.*'
+        uses: codecov/codecov-action@v5
         with:
           files: ./coverage.xml
           fail_ci_if_error: false
           token: ${{ secrets.CODECOV_TOKEN }}
+
+  lowest-deps:
+    name: Tests (lowest dependencies)
+    runs-on: ubuntu-latest
+
+    services:
+      redis:
+        image: redis:7-alpine
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 6379:6379
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.3'
+          extensions: mbstring, xml, ctype, iconv, redis
+          tools: composer:v2
+
+      # A bundle is installed against whatever its constraints allow, so the
+      # floor of those constraints has to be exercised too: it is where an
+      # accidentally-used newer API shows up.
+      - name: Install lowest dependencies
+        run: composer update --prefer-dist --prefer-lowest --no-interaction --no-progress
+
+      - name: Run tests
+        run: composer test
+        env:
+          REDIS_HOST: 127.0.0.1
 
   code-quality:
     name: Code Quality
@@ -88,7 +134,9 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: '8.4'
-          extensions: mbstring, xml, ctype, iconv
+          # ext-redis is required for PHPStan to resolve the \Redis class
+          # referenced by RedisHealthCheck.
+          extensions: mbstring, xml, ctype, iconv, redis
           tools: composer:v2
 
       - name: Get composer cache directory
@@ -99,8 +147,10 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
-          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
-          restore-keys: ${{ runner.os }}-composer-
+          # composer.lock is gitignored (this is a library), so the cache keys
+          # off composer.json instead.
+          key: ${{ runner.os }}-composer-quality-${{ hashFiles('**/composer.json') }}
+          restore-keys: ${{ runner.os }}-composer-quality-
 
       - name: Install dependencies
         run: composer install --prefer-dist --no-interaction --no-progress

--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -16,6 +16,9 @@ return $config->setRules([
         'not_operator_with_successor_space' => false,
         'trailing_comma_in_multiline' => true,
         'phpdoc_scalar' => true,
+        // @Symfony strips "@param mixed" as superfluous, but PHPStan level 9
+        // requires a type for every parameter. Keep them so the two tools agree.
+        'no_superfluous_phpdoc_tags' => ['allow_mixed' => true],
         'unary_operator_spaces' => true,
         'binary_operator_spaces' => true,
         'blank_line_before_statement' => [

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,44 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Criticality was attributed to the wrong check when filtering by group.**
+  `HealthCheckService` correlated results back to checks by array position,
+  which breaks as soon as a group filter skips one. A failing non-critical
+  check could return HTTP 503, and a failing critical check could be reported
+  as healthy. Criticality is now captured together with each result.
+- `/ping` and `/ready` were unreachable when importing the bundle's routing
+  file: only `/health` was declared, and `PingController` was not registered
+  as a service.
+- `S3HealthCheck` called `toArray()` on the bucket listing, paging through and
+  holding every object in memory. It now consumes a single entry.
+- `DatabaseHealthCheck` issued a bare `SELECT 1`, which is a syntax error on
+  Oracle and DB2. It now uses the DBAL platform's sentinel query.
+- `HealthCheckPass` read the `health_check.checks` parameter without checking
+  it exists, and matched built-in checks on a substring of the service id,
+  which could disable unrelated application services.
+- Health checks are injected as a lazy iterator again; the compiler pass had
+  replaced the tagged iterator with a plain array, instantiating every check
+  and its connections up front.
+- GrumPHP ran PHPStan without a memory limit (crashing the pre-commit hook) and
+  pinned level 8 while `phpstan.neon` declared level 9.
+
 ### Added
 
+- Optional PSR-3 logging in `AbstractHealthCheck`. Failures are recorded
+  server-side with their exception; HTTP responses stay generic.
+- Timeout overruns are detected and reported as degraded. `set_time_limit()`
+  cannot interrupt blocking I/O, so the declared timeout is verified after the
+  fact rather than assumed to have been enforced.
+- `HttpHealthCheck` accepts a Symfony `HttpClientInterface`. The stream-wrapper
+  fallback no longer downloads the response body and understands HTTP/2 status
+  lines.
+- `RedisHealthCheck` accepts a pre-configured `\Redis` client, so applications
+  can probe the connection they actually use.
+- `getHealthStatus()` accepts a `$group` argument and reuses the result cache.
+- Health check ordering via the `priority` attribute on the tag.
+- CI covers Symfony 8.x, PHP 8.5, and a lowest-dependencies run.
 - Initial bundle implementation
 - Health check interface and abstract base class
 - Built-in health checks:
@@ -21,5 +57,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Timeout management and exception handling
 - PHP 8.3+ features (enums, readonly, attributes)
 - Comprehensive documentation
+
+### Changed
+
+- **The overall status can now be `degraded`.** Previously a degraded check, or
+  a non-critical failure, was reported as `healthy`. Both now yield `degraded`,
+  which still maps to HTTP 200 — the HTTP contract is unchanged, but the
+  payload reports the condition instead of hiding it.
+- Controllers derive their HTTP code from `HealthCheckStatus` rather than
+  hardcoding `healthy ? 200 : 503`, which would have returned 503 for a
+  degraded application.
+- The result cache is scoped per group; a filtered run no longer serves results
+  computed for a different scope.
+- PHPStan level 9 now also analyses `tests/`.
 
 [Unreleased]: https://github.com/kiora/health-check-bundle/compare/v1.0.0...HEAD

--- a/README.md
+++ b/README.md
@@ -269,6 +269,19 @@ services:
             $critical: false  # Set to true if Redis failure should return 503
 ```
 
+If your application already builds its own Redis client — with TLS,
+authentication or specific timeouts — pass it as `$client` instead of `$host`
+and `$port`, so the check probes the connection the application actually uses:
+
+```yaml
+services:
+    Kiora\HealthCheckBundle\HealthCheck\Checks\RedisHealthCheck:
+        autoconfigure: true
+        arguments:
+            $client: '@app.redis_client'
+            $critical: false
+```
+
 **Step 3:** Add environment variables
 
 ```env
@@ -329,7 +342,14 @@ services:
             $timeout: 5
             $critical: false
             $expectedStatusCodes: [200, 401]  # 401 = API accessible but auth required
+            $httpClient: '@http_client'  # Recommended, see below
 ```
+
+**Pass an HTTP client when you can.** Without `$httpClient` the check falls back
+to PHP's stream wrapper, which requires `allow_url_fopen` to be enabled. Install
+`symfony/http-client` and inject `@http_client` for proper timeout, redirect and
+TLS handling. Either way the response body is never downloaded — only the status
+line is read.
 
 #### Example: Microsoft Graph API
 
@@ -540,14 +560,24 @@ The `statistics` section provides performance insights:
 
 ### Status Codes
 
-- **200 OK**: All critical checks passed
+- **200 OK**: All critical checks passed (overall status `healthy` or `degraded`)
 - **503 Service Unavailable**: One or more critical checks failed
 
 ### Check Status Values
 
 - `healthy`: Check passed successfully
 - `unhealthy`: Check failed
-- `degraded`: Check passed with warnings (reserved for future use)
+- `degraded`: Check passed with warnings, or exceeded its declared timeout
+
+### Overall Status
+
+The overall status aggregates the individual checks:
+
+- `unhealthy` — a **critical** check failed. Returns HTTP 503.
+- `degraded` — a check reported `degraded`, or a **non-critical** check failed.
+  Returns HTTP 200: the condition is reported to monitoring, but the instance
+  keeps serving traffic.
+- `healthy` — every check passed.
 
 ### Filtering Checks by Group
 
@@ -761,6 +791,21 @@ services:
 - Exception messages with sensitive data
 - Response sizes or client counts
 - Internal URLs or endpoints
+
+### Diagnosing Failures Without Leaking Detail
+
+Responses stay generic by design, which would otherwise leave you with
+`"Health check failed"` and no way to find out why. Checks extending
+`AbstractHealthCheck` implement PSR-3's `LoggerAwareInterface`, so with
+MonologBundle installed Symfony injects the logger automatically and the real
+exception is recorded server-side:
+
+```text
+[error] Health check "database" threw an exception {"check":"database","duration":2.014,"exception":"[object] (Doctrine\\DBAL\\Exception\\ConnectionException...)"}
+```
+
+The exception never reaches the HTTP response. Checks that exceed their declared
+timeout are logged as warnings and reported as `degraded`.
 
 ### Best Practices
 

--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,7 @@
     },
     "require": {
         "php": ">=8.3",
+        "psr/log": "^1.0|^2.0|^3.0",
         "symfony/framework-bundle": "^6.4|^7.0|^8.0",
         "symfony/dependency-injection": "^6.4|^7.0|^8.0",
         "symfony/config": "^6.4|^7.0|^8.0",
@@ -31,7 +32,14 @@
         "phpro/grumphp": "^2.0",
         "doctrine/dbal": "^3.0|^4.0",
         "league/flysystem": "^3.0",
-        "predis/predis": "^2.0"
+        "predis/predis": "^2.0",
+        "symfony/http-client-contracts": "^3.0|^4.0"
+    },
+    "suggest": {
+        "doctrine/dbal": "To use the built-in DatabaseHealthCheck",
+        "league/flysystem": "To use the built-in S3HealthCheck",
+        "ext-redis": "To use the built-in RedisHealthCheck",
+        "symfony/http-client": "To use HttpHealthCheck with a real HTTP client instead of the file_get_contents fallback"
     },
     "config": {
         "allow-plugins": {

--- a/config/routes.php
+++ b/config/routes.php
@@ -3,10 +3,24 @@
 declare(strict_types=1);
 
 use Kiora\HealthCheckBundle\Controller\HealthCheckController;
+use Kiora\HealthCheckBundle\Controller\PingController;
 use Symfony\Component\Routing\Loader\Configurator\RoutingConfigurator;
 
+/*
+ * Route names match the #[Route] attributes on the controllers so that either
+ * loading strategy yields the same names. Importing this file is the supported
+ * path: the bundle's controllers are not scanned for attributes by default.
+ */
 return static function (RoutingConfigurator $routes): void {
     $routes->add('health_check', '/health')
         ->controller([HealthCheckController::class, 'check'])
+        ->methods(['GET']);
+
+    $routes->add('health_readiness', '/ready')
+        ->controller([HealthCheckController::class, 'readiness'])
+        ->methods(['GET']);
+
+    $routes->add('health_ping', '/ping')
+        ->controller([PingController::class, 'ping'])
         ->methods(['GET']);
 };

--- a/config/services.php
+++ b/config/services.php
@@ -5,9 +5,8 @@ declare(strict_types=1);
 namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
 use Kiora\HealthCheckBundle\Controller\HealthCheckController;
+use Kiora\HealthCheckBundle\Controller\PingController;
 use Kiora\HealthCheckBundle\HealthCheck\Checks\DatabaseHealthCheck;
-use Kiora\HealthCheckBundle\HealthCheck\Checks\HttpHealthCheck;
-use Kiora\HealthCheckBundle\HealthCheck\Checks\RedisHealthCheck;
 use Kiora\HealthCheckBundle\Service\HealthCheckService;
 
 return static function (ContainerConfigurator $container): void {
@@ -21,8 +20,13 @@ return static function (ContainerConfigurator $container): void {
         ->arg('$healthChecks', tagged_iterator('health_check.checker'))
         ->public();
 
-    // Controller
+    // Controllers
     $services->set(HealthCheckController::class)
+        ->tag('controller.service_arguments');
+
+    // PingController performs no dependency checks, but still needs to be a
+    // registered service for the /ping route to resolve.
+    $services->set(PingController::class)
         ->tag('controller.service_arguments');
 
     // Built-in Health Checks

--- a/grumphp.yml
+++ b/grumphp.yml
@@ -1,8 +1,11 @@
 grumphp:
     tasks:
+        # Level is intentionally omitted: phpstan.neon is the single source of
+        # truth. Setting it here silently overrode that file with a laxer level.
         phpstan:
-            level: 8
             configuration: phpstan.neon
+            # Matches the composer script; the 128M default crashes the worker.
+            memory_limit: "256M"
         phpcsfixer:
             config: .php-cs-fixer.php
             allow_risky: true

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -3,6 +3,9 @@ includes:
 
 parameters:
     level: 9
+    # Tests are analysed too: GrumPHP feeds changed files to PHPStan, so
+    # excluding them here made the pre-commit hook fail on code the CI passed.
     paths:
         - src
+        - tests
     treatPhpDocTypesAsCertain: false

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,13 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd"
+         xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
          bootstrap="vendor/autoload.php"
          colors="true"
          cacheDirectory=".phpunit.cache"
          failOnRisky="true"
          failOnWarning="true"
+         failOnNotice="true"
+         failOnDeprecation="true"
          beStrictAboutOutputDuringTests="true"
-         beStrictAboutTodoAnnotatedTests="true">
+         beStrictAboutCoverageMetadata="false"
+         displayDetailsOnTestsThatTriggerErrors="true"
+         displayDetailsOnTestsThatTriggerWarnings="true"
+         displayDetailsOnTestsThatTriggerNotices="true"
+         displayDetailsOnTestsThatTriggerDeprecations="true"
+         displayDetailsOnPhpunitDeprecations="true">
     <testsuites>
         <testsuite name="Health Check Bundle Test Suite">
             <directory>tests</directory>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -21,7 +21,14 @@
         </testsuite>
     </testsuites>
 
-    <source>
+    <!--
+        restrictDeprecations limits failOnDeprecation to deprecations raised by
+        this bundle's own code. Without it, the lowest-dependencies CI run fails
+        on deprecations emitted inside vendor packages, which we cannot fix.
+    -->
+    <source restrictDeprecations="true"
+            restrictNotices="true"
+            restrictWarnings="true">
         <include>
             <directory>src</directory>
         </include>

--- a/src/Controller/HealthCheckController.php
+++ b/src/Controller/HealthCheckController.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Kiora\HealthCheckBundle\Controller;
 
+use Kiora\HealthCheckBundle\HealthCheck\HealthCheckStatus;
 use Kiora\HealthCheckBundle\Service\HealthCheckService;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\JsonResponse;
@@ -17,6 +18,25 @@ use Symfony\Component\Routing\Attribute\Route;
  */
 class HealthCheckController extends AbstractController
 {
+    /**
+     * Group probed by the readiness endpoint.
+     */
+    private const READINESS_GROUP = 'readiness';
+
+    /**
+     * Headers applied to every health response.
+     *
+     * Health output must never be cached by proxies or indexed by crawlers:
+     * a cached probe would report a state the application has already left.
+     *
+     * @var array<string, string>
+     */
+    private const RESPONSE_HEADERS = [
+        'X-Robots-Tag' => 'noindex, nofollow',
+        'X-Content-Type-Options' => 'nosniff',
+        'Cache-Control' => 'no-store, no-cache, must-revalidate, private',
+    ];
+
     public function __construct(
         private readonly HealthCheckService $healthCheckService
     ) {
@@ -25,7 +45,7 @@ class HealthCheckController extends AbstractController
     /**
      * Get the overall health status of the application.
      *
-     * Returns HTTP 200 if healthy, 503 if unhealthy.
+     * Returns HTTP 200 if healthy or degraded, 503 if unhealthy.
      * Supports optional ?group= query parameter to filter checks by group.
      *
      * @return JsonResponse JSON response with health check results
@@ -33,16 +53,9 @@ class HealthCheckController extends AbstractController
     #[Route('/health', name: 'health_check', methods: ['GET'])]
     public function check(Request $request): JsonResponse
     {
-        $group = $request->query->get('group');
-        $results = $this->healthCheckService->runAllChecks($group);
+        $results = $this->healthCheckService->runAllChecks($this->resolveGroup($request));
 
-        $statusCode = 'healthy' === $results['status'] ? 200 : 503;
-
-        return new JsonResponse($results, $statusCode, [
-            'X-Robots-Tag' => 'noindex, nofollow',
-            'X-Content-Type-Options' => 'nosniff',
-            'Cache-Control' => 'no-store, no-cache, must-revalidate, private',
-        ]);
+        return $this->respond($results);
     }
 
     /**
@@ -57,17 +70,41 @@ class HealthCheckController extends AbstractController
      * @return JsonResponse JSON response with readiness check results
      */
     #[Route('/ready', name: 'health_readiness', methods: ['GET'])]
-    public function readiness(Request $request): JsonResponse
+    public function readiness(?Request $request = null): JsonResponse
     {
-        // Only check "readiness" group
-        $results = $this->healthCheckService->runAllChecks('readiness');
+        $results = $this->healthCheckService->runAllChecks(self::READINESS_GROUP);
 
-        $statusCode = 'healthy' === $results['status'] ? 200 : 503;
+        return $this->respond($results);
+    }
 
-        return new JsonResponse($results, $statusCode, [
-            'X-Robots-Tag' => 'noindex, nofollow',
-            'X-Content-Type-Options' => 'nosniff',
-            'Cache-Control' => 'no-store, no-cache, must-revalidate, private',
-        ]);
+    /**
+     * Build the JSON response, deriving the HTTP code from the reported status.
+     *
+     * HealthCheckStatus is the single source of truth for the mapping, so a
+     * degraded application answers 200 instead of being pulled out of the load
+     * balancer rotation for a non-critical failure.
+     *
+     * @param array{status: string, timestamp: string, duration: float, checks: array<int, array<string, mixed>>, statistics: array<string, mixed>} $results
+     */
+    private function respond(array $results): JsonResponse
+    {
+        $statusCode = HealthCheckStatus::tryFrom($results['status'])?->getHttpStatusCode()
+            ?? HealthCheckStatus::UNHEALTHY->getHttpStatusCode();
+
+        return new JsonResponse($results, $statusCode, self::RESPONSE_HEADERS);
+    }
+
+    /**
+     * Read the optional group filter from the query string.
+     *
+     * Reads through all() so that a repeated or array-shaped parameter
+     * (?group[]=web) yields null instead of raising a bad-request exception:
+     * a malformed probe URL should not make the endpoint itself fail.
+     */
+    private function resolveGroup(Request $request): ?string
+    {
+        $group = $request->query->all()['group'] ?? null;
+
+        return is_string($group) && '' !== $group ? $group : null;
     }
 }

--- a/src/DependencyInjection/Compiler/HealthCheckPass.php
+++ b/src/DependencyInjection/Compiler/HealthCheckPass.php
@@ -4,7 +4,10 @@ declare(strict_types=1);
 
 namespace Kiora\HealthCheckBundle\DependencyInjection\Compiler;
 
+use Kiora\HealthCheckBundle\HealthCheck\Checks\DatabaseHealthCheck;
+use Kiora\HealthCheckBundle\HealthCheck\Checks\RedisHealthCheck;
 use Kiora\HealthCheckBundle\Service\HealthCheckService;
+use Symfony\Component\DependencyInjection\Argument\IteratorArgument;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Reference;
@@ -17,6 +20,19 @@ use Symfony\Component\DependencyInjection\Reference;
  */
 class HealthCheckPass implements CompilerPassInterface
 {
+    public const TAG_NAME = 'health_check.checker';
+
+    /**
+     * Built-in checks that the bundle configuration can switch off, mapped to
+     * their config key and their default state when the key is absent.
+     *
+     * @var array<class-string, array{key: string, default: bool}>
+     */
+    private const TOGGLEABLE_CHECKS = [
+        DatabaseHealthCheck::class => ['key' => 'database', 'default' => true],
+        RedisHealthCheck::class => ['key' => 'redis', 'default' => false],
+    ];
+
     public function process(ContainerBuilder $container): void
     {
         // Check if the HealthCheckService exists
@@ -24,37 +40,110 @@ class HealthCheckPass implements CompilerPassInterface
             return;
         }
 
-        // Get configuration
-        $config = $container->getParameter('health_check.checks');
-
+        $config = $this->getChecksConfig($container);
         $definition = $container->findDefinition(HealthCheckService::class);
 
-        // Find all services tagged with 'health_check.checker'
-        $taggedServices = $container->findTaggedServiceIds('health_check.checker');
-
         $references = [];
-        foreach (array_keys($taggedServices) as $id) {
-            // Check if this is a built-in check that can be disabled
-            $shouldInclude = true;
 
-            // Database check
-            if (str_contains($id, 'DatabaseHealthCheck')) {
-                $shouldInclude = $config['database']['enabled'] ?? true;
-            }
-            // Redis check
-            elseif (str_contains($id, 'RedisHealthCheck')) {
-                $shouldInclude = $config['redis']['enabled'] ?? false;
+        foreach ($this->getSortedTaggedIds($container) as $id) {
+            if (!$this->isEnabled($container, $id, $config)) {
+                // Only definitions can be removed; a tagged alias would raise here.
+                if ($container->hasDefinition($id)) {
+                    $container->removeDefinition($id);
+                }
+
+                continue;
             }
 
-            if ($shouldInclude) {
-                $references[] = new Reference($id);
-            } else {
-                // Remove the service definition if disabled
-                $container->removeDefinition($id);
-            }
+            $references[] = new Reference($id);
         }
 
-        // Inject all enabled health checks into the service
-        $definition->setArgument('$healthChecks', $references);
+        // Wrap in an IteratorArgument so checks keep being instantiated lazily,
+        // as they are with tagged_iterator. A plain array of references would
+        // construct every check — and every connection they hold — up front.
+        $definition->setArgument('$healthChecks', new IteratorArgument($references));
+    }
+
+    /**
+     * Read the bundle's per-check configuration.
+     *
+     * The parameter is missing whenever the extension has not run — for
+     * instance when the compiler pass is exercised on its own — so the absence
+     * must not be fatal.
+     *
+     * @return array<string, mixed>
+     */
+    private function getChecksConfig(ContainerBuilder $container): array
+    {
+        if (!$container->hasParameter('health_check.checks')) {
+            return [];
+        }
+
+        $config = $container->getParameter('health_check.checks');
+
+        return is_array($config) ? $config : [];
+    }
+
+    /**
+     * Collect tagged service ids, ordered by descending tag priority.
+     *
+     * @return list<string>
+     */
+    private function getSortedTaggedIds(ContainerBuilder $container): array
+    {
+        $entries = [];
+
+        foreach ($container->findTaggedServiceIds(self::TAG_NAME) as $id => $tags) {
+            $priority = 0;
+
+            foreach ($tags as $attributes) {
+                if (isset($attributes['priority']) && is_numeric($attributes['priority'])) {
+                    $priority = (int) $attributes['priority'];
+
+                    break;
+                }
+            }
+
+            $entries[] = ['id' => $id, 'priority' => $priority];
+        }
+
+        // usort is stable as of PHP 8.0, so equal priorities keep registration order.
+        usort($entries, static fn (array $a, array $b): int => $b['priority'] <=> $a['priority']);
+
+        return array_map(static fn (array $entry): string => $entry['id'], $entries);
+    }
+
+    /**
+     * Determine whether a tagged check should be injected.
+     *
+     * Resolution is based on the service's actual class rather than a substring
+     * of its id: matching on the id alone would silently disable an unrelated
+     * application service whose name happens to contain "DatabaseHealthCheck".
+     *
+     * @param array<string, mixed> $config
+     */
+    private function isEnabled(ContainerBuilder $container, string $id, array $config): bool
+    {
+        $class = $container->hasDefinition($id) ? $container->getDefinition($id)->getClass() : null;
+
+        if (null === $class) {
+            return true;
+        }
+
+        foreach (self::TOGGLEABLE_CHECKS as $builtIn => $toggle) {
+            if ($class !== $builtIn && !is_subclass_of($class, $builtIn)) {
+                continue;
+            }
+
+            $checkConfig = $config[$toggle['key']] ?? null;
+
+            if (is_array($checkConfig) && isset($checkConfig['enabled'])) {
+                return (bool) $checkConfig['enabled'];
+            }
+
+            return $toggle['default'];
+        }
+
+        return true;
     }
 }

--- a/src/HealthCheck/AbstractHealthCheck.php
+++ b/src/HealthCheck/AbstractHealthCheck.php
@@ -4,15 +4,32 @@ declare(strict_types=1);
 
 namespace Kiora\HealthCheckBundle\HealthCheck;
 
+use Psr\Log\LoggerAwareInterface;
+use Psr\Log\LoggerInterface;
+
 /**
  * Abstract base class for health checks.
  *
  * Provides automatic timeout management, execution time measurement,
  * and exception handling. Concrete implementations only need to
  * implement the doCheck() method.
+ *
+ * Implements LoggerAwareInterface: when MonologBundle is installed, Symfony
+ * injects the logger automatically. Failures are then recorded server-side
+ * with their full exception detail while HTTP responses stay generic.
  */
-abstract class AbstractHealthCheck implements HealthCheckInterface
+abstract class AbstractHealthCheck implements HealthCheckInterface, LoggerAwareInterface
 {
+    protected ?LoggerInterface $logger = null;
+
+    /**
+     * Inject a PSR-3 logger used to record check failures internally.
+     */
+    public function setLogger(LoggerInterface $logger): void
+    {
+        $this->logger = $logger;
+    }
+
     /**
      * Execute the health check with timeout and error handling.
      */
@@ -21,26 +38,22 @@ abstract class AbstractHealthCheck implements HealthCheckInterface
         $startTime = microtime(true);
         $timeout = $this->getTimeout();
 
-        // Set maximum execution time for this check
-        $previousTimeout = ini_get('max_execution_time');
-        set_time_limit($timeout);
+        $previousTimeout = $this->applyTimeLimit($timeout);
 
         try {
             $result = $this->doCheck();
-
-            // Calculate actual duration
             $duration = microtime(true) - $startTime;
 
-            // Return result with measured duration
-            return new HealthCheckResult(
-                name: $result->name,
-                status: $result->status,
-                message: $result->message,
-                duration: $duration,
-                metadata: $result->metadata
-            );
+            return $this->finalizeResult($result, $duration, $timeout);
         } catch (\Throwable $e) {
             $duration = microtime(true) - $startTime;
+
+            // Log the real cause internally; the response stays generic on purpose.
+            $this->logger?->error('Health check "{check}" threw an exception', [
+                'check' => $this->getName(),
+                'duration' => round($duration, 3),
+                'exception' => $e,
+            ]);
 
             return new HealthCheckResult(
                 name: $this->getName(),
@@ -50,9 +63,67 @@ abstract class AbstractHealthCheck implements HealthCheckInterface
                 metadata: []
             );
         } finally {
-            // Restore previous timeout (cast to int, 0 if false/empty)
-            set_time_limit(false !== $previousTimeout ? (int) $previousTimeout : 0);
+            if (null !== $previousTimeout) {
+                $this->applyTimeLimit($previousTimeout);
+            }
         }
+    }
+
+    /**
+     * Attach the measured duration to a result and flag timeout overruns.
+     *
+     * set_time_limit() does not interrupt time spent in blocking I/O — a
+     * stalled socket read can outlive the limit entirely — so the declared
+     * timeout cannot be enforced preemptively. Measuring afterwards is what
+     * makes an overrun visible: a check that succeeded but took longer than
+     * it promised is reported as degraded rather than silently healthy.
+     */
+    private function finalizeResult(HealthCheckResult $result, float $duration, int $timeout): HealthCheckResult
+    {
+        $status = $result->status;
+        $message = $result->message;
+
+        if ($timeout > 0 && $duration > $timeout && !$status->isUnhealthy()) {
+            $this->logger?->warning('Health check "{check}" exceeded its timeout', [
+                'check' => $this->getName(),
+                'duration' => round($duration, 3),
+                'timeout' => $timeout,
+            ]);
+
+            $status = HealthCheckStatus::DEGRADED;
+            $message = $result->message.' (exceeded timeout)';
+        }
+
+        return new HealthCheckResult(
+            name: $result->name,
+            status: $status,
+            message: $message,
+            duration: $duration,
+            metadata: $result->metadata
+        );
+    }
+
+    /**
+     * Set the PHP time limit, returning the previous value for restoration.
+     *
+     * Returns null when the limit could not be changed — set_time_limit() is
+     * commonly disabled via disable_functions, and it is a no-op in CLI where
+     * max_execution_time is already unlimited. In that case the caller skips
+     * restoration instead of emitting a second failing call.
+     */
+    private function applyTimeLimit(int $seconds): ?int
+    {
+        if ($seconds < 0 || !function_exists('set_time_limit')) {
+            return null;
+        }
+
+        $previous = ini_get('max_execution_time');
+
+        if (!@set_time_limit($seconds)) {
+            return null;
+        }
+
+        return false !== $previous ? (int) $previous : 0;
     }
 
     /**

--- a/src/HealthCheck/Checks/DatabaseHealthCheck.php
+++ b/src/HealthCheck/Checks/DatabaseHealthCheck.php
@@ -58,15 +58,33 @@ class DatabaseHealthCheck extends AbstractHealthCheck
     {
         try {
             // Execute a simple query to verify connection
-            $result = $this->connection->fetchOne('SELECT 1');
+            $result = $this->connection->fetchOne($this->getSentinelQuery());
 
             if (1 !== $result && '1' !== $result) {
                 return $this->createUnhealthyResult('Database query failed');
             }
 
             return $this->createHealthyResult('Database operational');
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
             return $this->createUnhealthyResult('Database connection failed');
+        }
+    }
+
+    /**
+     * Build a platform-portable sentinel query.
+     *
+     * A bare "SELECT 1" is a syntax error on platforms that require a FROM
+     * clause — Oracle needs "FROM DUAL", DB2 needs "FROM SYSIBM.SYSDUMMY1" —
+     * so the check would report those databases as down while they are fine.
+     * DBAL knows the correct form per platform; fall back to the literal when
+     * the platform cannot be resolved (which needs a live connection itself).
+     */
+    private function getSentinelQuery(): string
+    {
+        try {
+            return $this->connection->getDatabasePlatform()->getDummySelectSQL();
+        } catch (\Throwable $e) {
+            return 'SELECT 1';
         }
     }
 }

--- a/src/HealthCheck/Checks/HttpHealthCheck.php
+++ b/src/HealthCheck/Checks/HttpHealthCheck.php
@@ -6,6 +6,7 @@ namespace Kiora\HealthCheckBundle\HealthCheck\Checks;
 
 use Kiora\HealthCheckBundle\HealthCheck\AbstractHealthCheck;
 use Kiora\HealthCheckBundle\HealthCheck\HealthCheckResult;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 /**
  * Health check for HTTP endpoints.
@@ -13,17 +14,29 @@ use Kiora\HealthCheckBundle\HealthCheck\HealthCheckResult;
  * Monitors external HTTP endpoints to verify they are accessible
  * and returning expected status codes.
  *
+ * Pass a Symfony HttpClient to $httpClient when available: it handles
+ * timeouts, redirects and TLS properly. Without one, the check falls back to
+ * a stream wrapper, which requires allow_url_fopen to be enabled.
+ *
  * Automatically tagged with 'health_check.checker' via interface.
  */
 class HttpHealthCheck extends AbstractHealthCheck
 {
     /**
-     * @param string   $url                 The URL to check
-     * @param string   $name                Optional custom name for this check
-     * @param int      $timeout             Timeout in seconds
-     * @param bool     $critical            Whether this check is critical
-     * @param int[]    $expectedStatusCodes Expected HTTP status codes (default: 200, 201, 204)
-     * @param string[] $groups              Groups this check belongs to (e.g., ['web', 'worker'])
+     * Matches the status line of both HTTP/1.x ("HTTP/1.1 200 OK") and
+     * HTTP/2 ("HTTP/2 200"), which omits the minor version.
+     */
+    private const STATUS_LINE_PATTERN = '#^HTTP/\d(?:\.\d)?\s+(\d{3})#i';
+
+    /**
+     * @param string                   $url                 The URL to check
+     * @param string                   $name                Optional custom name for this check
+     * @param int                      $timeout             Timeout in seconds
+     * @param bool                     $critical            Whether this check is critical
+     * @param int[]                    $expectedStatusCodes Expected HTTP status codes (default: 200, 201, 204)
+     * @param string[]                 $groups              Groups this check belongs to (e.g., ['web', 'worker'])
+     * @param HttpClientInterface|null $httpClient          Optional Symfony HTTP client (recommended)
+     * @param int                      $maxRedirects        Maximum number of redirects to follow
      */
     public function __construct(
         private readonly string $url,
@@ -31,7 +44,9 @@ class HttpHealthCheck extends AbstractHealthCheck
         private readonly int $timeout = 5,
         private readonly bool $critical = false,
         private readonly array $expectedStatusCodes = [200, 201, 204],
-        private readonly array $groups = []
+        private readonly array $groups = [],
+        private readonly ?HttpClientInterface $httpClient = null,
+        private readonly int $maxRedirects = 3
     ) {
     }
 
@@ -58,38 +73,97 @@ class HttpHealthCheck extends AbstractHealthCheck
     protected function doCheck(): HealthCheckResult
     {
         try {
-            // Create stream context with timeout
-            $context = stream_context_create([
-                'http' => [
-                    'method' => 'GET',
-                    'timeout' => $this->timeout,
-                    'ignore_errors' => true,
-                ],
-            ]);
+            $statusCode = null !== $this->httpClient
+                ? $this->fetchStatusWithClient($this->httpClient)
+                : $this->fetchStatusWithStream();
 
-            // Perform HTTP request
-            $response = @file_get_contents($this->url, false, $context);
-
-            if (false === $response) {
+            if (null === $statusCode) {
                 return $this->createUnhealthyResult('HTTP endpoint unreachable');
             }
 
-            // Parse HTTP response code
-            $statusCode = 0;
-            // @phpstan-ignore-next-line - $http_response_header is a magic variable set by file_get_contents()
-            if (count($http_response_header ?? []) > 0) {
-                preg_match('/HTTP\/\d\.\d\s+(\d+)/', $http_response_header[0], $matches);
-                $statusCode = (int) ($matches[1] ?? 0);
-            }
-
-            // Check if status code is expected
             if (!in_array($statusCode, $this->expectedStatusCodes, true)) {
                 return $this->createUnhealthyResult('HTTP endpoint returned unexpected status');
             }
 
             return $this->createHealthyResult('HTTP endpoint operational');
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
             return $this->createUnhealthyResult('HTTP check failed');
         }
+    }
+
+    /**
+     * Fetch the status code using a Symfony HTTP client.
+     *
+     * getStatusCode() resolves as soon as the response headers arrive, so the
+     * body is never downloaded.
+     *
+     * @return int|null Null when the endpoint could not be reached
+     */
+    private function fetchStatusWithClient(HttpClientInterface $client): ?int
+    {
+        try {
+            return $client->request('GET', $this->url, [
+                'timeout' => (float) $this->timeout,
+                'max_redirects' => $this->maxRedirects,
+            ])->getStatusCode();
+        } catch (\Throwable $e) {
+            return null;
+        }
+    }
+
+    /**
+     * Fetch the status code using the HTTP stream wrapper.
+     *
+     * Opens the stream and reads only its metadata instead of calling
+     * file_get_contents(): the body of a monitored endpoint can be arbitrarily
+     * large, and pulling it into memory on every probe is wasteful. Reading the
+     * headers off the handle also avoids the $http_response_header magic
+     * variable, whose scoping rules make it easy to read a stale value.
+     *
+     * @return int|null Null when the endpoint could not be reached
+     */
+    private function fetchStatusWithStream(): ?int
+    {
+        $context = stream_context_create([
+            'http' => [
+                'method' => 'GET',
+                'timeout' => $this->timeout,
+                'ignore_errors' => true,
+                'follow_location' => $this->maxRedirects > 0 ? 1 : 0,
+                'max_redirects' => max(1, $this->maxRedirects),
+                'protocol_version' => 1.1,
+                'header' => "Connection: close\r\n",
+            ],
+        ]);
+
+        $stream = @fopen($this->url, 'r', false, $context);
+
+        if (false === $stream) {
+            return null;
+        }
+
+        try {
+            $metadata = stream_get_meta_data($stream);
+        } finally {
+            fclose($stream);
+        }
+
+        $headers = $metadata['wrapper_data'] ?? [];
+
+        if (!is_array($headers)) {
+            return null;
+        }
+
+        // With follow_location the wrapper keeps the status line of every hop;
+        // the last one is the response actually being judged.
+        $statusCode = null;
+
+        foreach ($headers as $header) {
+            if (is_string($header) && 1 === preg_match(self::STATUS_LINE_PATTERN, $header, $matches)) {
+                $statusCode = (int) $matches[1];
+            }
+        }
+
+        return $statusCode;
     }
 }

--- a/src/HealthCheck/Checks/RedisHealthCheck.php
+++ b/src/HealthCheck/Checks/RedisHealthCheck.php
@@ -11,11 +11,12 @@ use Kiora\HealthCheckBundle\HealthCheck\HealthCheckResult;
  * Health check for Redis connectivity.
  *
  * Verifies that Redis is available and responsive by sending a PING command.
- * Supports both PHP Redis extension and Predis library.
  *
- * Uses persistent connections to reduce connection overhead and improve performance.
- * Connection is reused across multiple health check executions and automatically
- * recreated if it becomes disconnected.
+ * By default the check manages its own persistent connection to $host:$port,
+ * reusing it across executions and recreating it when it drops. Applications
+ * that already have a configured client — a tuned phpredis instance, a TLS or
+ * authenticated connection — should pass it as $client instead, so the check
+ * probes the same connection the application actually uses.
  *
  * Automatically tagged with 'health_check.checker' via interface.
  */
@@ -28,17 +29,31 @@ class RedisHealthCheck extends AbstractHealthCheck
     private ?\Redis $connection = null;
 
     /**
-     * @param string   $host     Redis host
-     * @param int      $port     Redis port
-     * @param bool     $critical Whether this check is critical
-     * @param string[] $groups   Groups this check belongs to (e.g., ['web', 'worker'])
+     * Whether the connection was supplied by the caller.
+     *
+     * An injected client is owned by the application, so it is never discarded
+     * on failure: this check has no way to rebuild an equivalent one.
+     */
+    private readonly bool $hasInjectedConnection;
+
+    /**
+     * @param string      $host           Redis host
+     * @param int         $port           Redis port
+     * @param bool        $critical       Whether this check is critical
+     * @param string[]    $groups         Groups this check belongs to (e.g., ['web', 'worker'])
+     * @param \Redis|null $client         Optional pre-configured client to probe instead of connecting
+     * @param float       $connectTimeout Connection timeout in seconds
      */
     public function __construct(
         private readonly string $host = 'localhost',
         private readonly int $port = 6379,
         private readonly bool $critical = false,
-        private readonly array $groups = []
+        private readonly array $groups = [],
+        ?\Redis $client = null,
+        private readonly float $connectTimeout = 2.0
     ) {
+        $this->connection = $client;
+        $this->hasInjectedConnection = null !== $client;
     }
 
     public function getName(): string
@@ -69,23 +84,23 @@ class RedisHealthCheck extends AbstractHealthCheck
             // Send PING command to Redis
             $response = $redis->ping();
 
-            // Check response
-            // phpredis returns true, Predis string client returns '+PONG' or 'PONG'
+            // phpredis returns true (or '+PONG' in multi/raw mode)
             $isPongValid = true === $response
                 || '+PONG' === $response
                 || 'PONG' === $response;
 
             if (!$isPongValid) {
-                // Reset connection on ping failure to allow recovery
-                $this->connection = null;
+                $this->discardConnection();
 
                 return $this->createUnhealthyResult('Redis ping failed');
             }
 
             return $this->createHealthyResult('Redis operational');
-        } catch (\Exception $e) {
-            // Reset connection on failure to allow recovery on next check
-            $this->connection = null;
+        } catch (\Throwable $e) {
+            // Catches \Throwable rather than \Exception: a missing ext-redis
+            // raises an Error on `new \Redis()`, which must degrade to an
+            // unhealthy result instead of escaping as a fatal error.
+            $this->discardConnection();
 
             return $this->createUnhealthyResult('Redis connection failed');
         }
@@ -94,9 +109,8 @@ class RedisHealthCheck extends AbstractHealthCheck
     /**
      * Get or create a persistent Redis connection.
      *
-     * Reuses existing connection if it's still connected, otherwise creates
-     * a new persistent connection. This reduces connection overhead and
-     * improves health check performance.
+     * Reuses an existing connection while it is still live, otherwise opens a
+     * new persistent one. This keeps repeated probes cheap.
      *
      * @throws \RuntimeException If connection cannot be established
      */
@@ -107,17 +121,35 @@ class RedisHealthCheck extends AbstractHealthCheck
             return $this->connection;
         }
 
-        // Create new persistent connection
+        if ($this->hasInjectedConnection && null !== $this->connection) {
+            // The application owns this client; probe it as-is and let ping()
+            // surface whatever is wrong rather than reconnecting behind its back.
+            return $this->connection;
+        }
+
+        if (!class_exists(\Redis::class)) {
+            throw new \RuntimeException('The redis extension is not installed');
+        }
+
         $this->connection = new \Redis();
 
         // Use pconnect for persistent connections across multiple health checks
-        // Timeout of 2 seconds for connection establishment
-        if (!@$this->connection->pconnect($this->host, $this->port, 2)) {
+        if (!@$this->connection->pconnect($this->host, $this->port, $this->connectTimeout)) {
             $this->connection = null;
 
             throw new \RuntimeException(sprintf('Failed to establish persistent connection to Redis at %s:%d', $this->host, $this->port));
         }
 
         return $this->connection;
+    }
+
+    /**
+     * Drop a self-managed connection so the next check can reconnect.
+     */
+    private function discardConnection(): void
+    {
+        if (!$this->hasInjectedConnection) {
+            $this->connection = null;
+        }
     }
 }

--- a/src/HealthCheck/Checks/S3HealthCheck.php
+++ b/src/HealthCheck/Checks/S3HealthCheck.php
@@ -55,11 +55,18 @@ class S3HealthCheck extends AbstractHealthCheck
     protected function doCheck(): HealthCheckResult
     {
         try {
-            // Try to list files (limit to 1) to verify bucket access
-            $this->filesystem->listContents('/', false)->toArray();
+            // Pull a single entry rather than calling toArray(): that would page
+            // through every object in the bucket and hold them all in memory,
+            // which on a large bucket turns this check into an outage of its own.
+            // Reaching the first entry already proves the bucket is listable.
+            foreach ($this->filesystem->listContents('/', false) as $entry) {
+                unset($entry);
+
+                break;
+            }
 
             return $this->createHealthyResult('S3 storage operational');
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
             return $this->createUnhealthyResult('S3 storage connection failed');
         }
     }

--- a/src/Service/HealthCheckService.php
+++ b/src/Service/HealthCheckService.php
@@ -22,11 +22,27 @@ class HealthCheckService
     private const CACHE_TTL = 1;
 
     /**
-     * @var array<int, HealthCheckResult>|null
+     * Cache key used when no group filter is applied.
+     *
+     * Prefixed with a NUL byte so it can never collide with a user-defined
+     * group name.
      */
-    private ?array $cachedResults = null;
+    private const CACHE_KEY_ALL = "\0all";
 
-    private ?float $cacheTimestamp = null;
+    /**
+     * Threshold in seconds above which a check is reported as slow.
+     */
+    private const SLOW_CHECK_THRESHOLD = 1.0;
+
+    /**
+     * Per-group result cache.
+     *
+     * Keyed by group name (or self::CACHE_KEY_ALL when unfiltered) so that a
+     * filtered run never serves results computed for a different scope.
+     *
+     * @var array<string, array{executions: list<array{result: HealthCheckResult, critical: bool}>, timestamp: float}>
+     */
+    private array $cache = [];
 
     /**
      * @param iterable<HealthCheckInterface> $healthChecks
@@ -42,68 +58,137 @@ class HealthCheckService
      * @param string|null $group    Optional group filter (e.g., 'web', 'worker', 'console')
      * @param bool        $useCache Whether to use cached results if available (default: true)
      *
-     * @return array{status: string, timestamp: string, duration: float, checks: array<int, array<string, mixed>>, statistics: array<string, mixed>}
+     * @return array{status: string, timestamp: string, duration: float, checks: array<int, array<string, mixed>>, statistics: array{total_checks: int, slow_checks: int, average_duration: float, slowest_check: array{name: string, duration: float}|null}}
      */
     public function runAllChecks(?string $group = null, bool $useCache = true): array
     {
         $startTime = microtime(true);
 
-        // Check if cache is fresh and should be used
-        if ($useCache && $this->isCacheFresh() && null === $group && null !== $this->cachedResults) {
-            $results = $this->cachedResults;
-        } else {
-            $results = [];
+        $executions = $this->getExecutions($group, $useCache);
 
-            foreach ($this->healthChecks as $healthCheck) {
-                // Filter by group if specified
-                if (null !== $group && !$this->checkBelongsToGroup($healthCheck, $group)) {
-                    continue;
-                }
-
-                $result = $healthCheck->check();
-                $results[] = $result;
-            }
-
-            // Cache results only when no group filter is applied
-            if (null === $group) {
-                $this->cachedResults = $results;
-                $this->cacheTimestamp = microtime(true);
-            }
-        }
-
-        // Recalculate overall status from results
-        $overallStatus = HealthCheckStatus::HEALTHY;
-        $healthCheckArray = iterator_to_array($this->healthChecks);
-        foreach ($results as $index => $result) {
-            $healthCheck = $healthCheckArray[$index] ?? null;
-            if (null !== $healthCheck && $result->isUnhealthy() && $healthCheck->isCritical()) {
-                $overallStatus = HealthCheckStatus::UNHEALTHY;
-
-                break;
-            }
-        }
+        $results = array_map(
+            static fn (array $execution): HealthCheckResult => $execution['result'],
+            $executions
+        );
 
         $totalDuration = microtime(true) - $startTime;
 
-        // Calculate statistics
-        $statistics = $this->calculateStatistics($results);
-
         return [
-            'status' => $overallStatus->value,
+            'status' => $this->resolveOverallStatus($executions)->value,
             'timestamp' => (new \DateTimeImmutable())->format(\DateTimeInterface::ATOM),
             'duration' => round($totalDuration, 3),
             'checks' => array_map(
                 static fn (HealthCheckResult $result): array => $result->toArray(),
                 $results
             ),
-            'statistics' => $statistics,
+            'statistics' => $this->calculateStatistics($results),
         ];
+    }
+
+    /**
+     * Get the overall health status.
+     *
+     * Returns the status used to derive the HTTP response code.
+     * Uses cached results if available to avoid re-executing checks.
+     *
+     * @param bool        $useCache Whether to use cached results if available (default: true)
+     * @param string|null $group    Optional group filter, matching runAllChecks()
+     */
+    public function getHealthStatus(bool $useCache = true, ?string $group = null): HealthCheckStatus
+    {
+        return $this->resolveOverallStatus($this->getExecutions($group, $useCache));
+    }
+
+    /**
+     * Execute a specific health check by name.
+     *
+     * @return HealthCheckResult|null Null if check not found
+     */
+    public function runCheck(string $name): ?HealthCheckResult
+    {
+        foreach ($this->healthChecks as $healthCheck) {
+            if ($healthCheck->getName() === $name) {
+                return $healthCheck->check();
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Get check executions for a group, served from cache when still fresh.
+     *
+     * Each execution pairs a result with the criticality of the check that
+     * produced it. Capturing both together is what keeps criticality correct:
+     * correlating results back to checks by position breaks as soon as a group
+     * filter skips one, which would attribute a failure to the wrong check.
+     *
+     * @return list<array{result: HealthCheckResult, critical: bool}>
+     */
+    private function getExecutions(?string $group, bool $useCache): array
+    {
+        $cacheKey = $group ?? self::CACHE_KEY_ALL;
+
+        if ($useCache && $this->isCacheFresh($cacheKey)) {
+            return $this->cache[$cacheKey]['executions'];
+        }
+
+        $executions = [];
+
+        foreach ($this->healthChecks as $healthCheck) {
+            // Filter by group if specified
+            if (null !== $group && !$this->checkBelongsToGroup($healthCheck, $group)) {
+                continue;
+            }
+
+            $executions[] = [
+                'result' => $healthCheck->check(),
+                'critical' => $healthCheck->isCritical(),
+            ];
+        }
+
+        $this->cache[$cacheKey] = [
+            'executions' => $executions,
+            'timestamp' => microtime(true),
+        ];
+
+        return $executions;
+    }
+
+    /**
+     * Determine the overall status from a set of executions.
+     *
+     * A failing critical check makes the whole application unhealthy (503).
+     * Anything else that is not fully operational — a degraded check, or a
+     * non-critical check that failed — is reported as degraded (200), so the
+     * condition stays visible to monitoring without pulling the instance out
+     * of the load balancer rotation.
+     *
+     * @param list<array{result: HealthCheckResult, critical: bool}> $executions
+     */
+    private function resolveOverallStatus(array $executions): HealthCheckStatus
+    {
+        $status = HealthCheckStatus::HEALTHY;
+
+        foreach ($executions as $execution) {
+            $result = $execution['result'];
+
+            if ($result->isUnhealthy() && $execution['critical']) {
+                return HealthCheckStatus::UNHEALTHY;
+            }
+
+            if ($result->isUnhealthy() || $result->status->isDegraded()) {
+                $status = HealthCheckStatus::DEGRADED;
+            }
+        }
+
+        return $status;
     }
 
     /**
      * Calculate performance statistics from health check results.
      *
-     * @param array<int, HealthCheckResult> $results
+     * @param list<HealthCheckResult> $results
      *
      * @return array{total_checks: int, slow_checks: int, average_duration: float, slowest_check: array{name: string, duration: float}|null}
      */
@@ -111,10 +196,10 @@ class HealthCheckService
     {
         $totalChecks = count($results);
 
-        // Identify slow checks (execution time > 1 second)
+        // Identify slow checks
         $slowChecks = array_filter(
             $results,
-            static fn (HealthCheckResult $result): bool => $result->duration > 1.0
+            static fn (HealthCheckResult $result): bool => $result->duration > self::SLOW_CHECK_THRESHOLD
         );
 
         // Find the slowest check
@@ -158,65 +243,14 @@ class HealthCheckService
     }
 
     /**
-     * Get the overall health status.
-     *
-     * Returns the appropriate HTTP status code based on health check results.
-     * Uses cached results if available to avoid re-executing checks.
-     *
-     * @param bool $useCache Whether to use cached results if available (default: true)
+     * Check if the cache for a given key is still fresh (within TTL).
      */
-    public function getHealthStatus(bool $useCache = true): HealthCheckStatus
+    private function isCacheFresh(string $cacheKey): bool
     {
-        // Use cached results if available and fresh
-        if ($useCache && $this->isCacheFresh() && null !== $this->cachedResults) {
-            $healthCheckArray = iterator_to_array($this->healthChecks);
-            foreach ($this->cachedResults as $index => $result) {
-                $healthCheck = $healthCheckArray[$index] ?? null;
-                if (null !== $healthCheck && $result->isUnhealthy() && $healthCheck->isCritical()) {
-                    return HealthCheckStatus::UNHEALTHY;
-                }
-            }
-
-            return HealthCheckStatus::HEALTHY;
-        }
-
-        // Execute checks if cache is not available
-        foreach ($this->healthChecks as $healthCheck) {
-            $result = $healthCheck->check();
-
-            if ($result->isUnhealthy() && $healthCheck->isCritical()) {
-                return HealthCheckStatus::UNHEALTHY;
-            }
-        }
-
-        return HealthCheckStatus::HEALTHY;
-    }
-
-    /**
-     * Check if the cache is still fresh (within TTL).
-     */
-    private function isCacheFresh(): bool
-    {
-        if (null === $this->cachedResults || null === $this->cacheTimestamp) {
+        if (!isset($this->cache[$cacheKey])) {
             return false;
         }
 
-        return (microtime(true) - $this->cacheTimestamp) < self::CACHE_TTL;
-    }
-
-    /**
-     * Execute a specific health check by name.
-     *
-     * @return HealthCheckResult|null Null if check not found
-     */
-    public function runCheck(string $name): ?HealthCheckResult
-    {
-        foreach ($this->healthChecks as $healthCheck) {
-            if ($healthCheck->getName() === $name) {
-                return $healthCheck->check();
-            }
-        }
-
-        return null;
+        return (microtime(true) - $this->cache[$cacheKey]['timestamp']) < self::CACHE_TTL;
     }
 }

--- a/tests/Controller/HealthCheckControllerTest.php
+++ b/tests/Controller/HealthCheckControllerTest.php
@@ -153,7 +153,7 @@ class HealthCheckControllerTest extends TestCase
         $request = new Request();
         $response = $controller->check($request);
 
-        $data = json_decode($response->getContent(), true);
+        $data = json_decode((string) $response->getContent(), true);
         $this->assertIsArray($data);
         $this->assertArrayHasKey('status', $data);
         $this->assertArrayHasKey('timestamp', $data);
@@ -233,7 +233,7 @@ class HealthCheckControllerTest extends TestCase
         $this->assertInstanceOf(JsonResponse::class, $response);
         $this->assertEquals(200, $response->getStatusCode());
 
-        $data = json_decode($response->getContent(), true);
+        $data = json_decode((string) $response->getContent(), true);
         $this->assertIsArray($data);
         $this->assertArrayHasKey('checks', $data);
         $this->assertEmpty($data['checks']);
@@ -263,6 +263,103 @@ class HealthCheckControllerTest extends TestCase
         $this->assertStringContainsString('no-cache', $cacheControl);
         $this->assertStringContainsString('must-revalidate', $cacheControl);
         $this->assertStringContainsString('private', $cacheControl);
+    }
+
+    /**
+     * A degraded application still serves traffic.
+     *
+     * Only a critical failure warrants 503; answering 503 for a degraded state
+     * would pull the instance out of rotation over a non-critical dependency.
+     */
+    public function testCheckReturns200WhenDegraded(): void
+    {
+        $service = $this->createMock(HealthCheckService::class);
+        $service->method('runAllChecks')->willReturn([
+            'status' => 'degraded',
+            'timestamp' => '2024-01-01T00:00:00+00:00',
+            'duration' => 0.123,
+            'checks' => [],
+        ]);
+
+        $controller = new HealthCheckController($service);
+        $response = $controller->check(new Request());
+
+        $this->assertEquals(200, $response->getStatusCode());
+    }
+
+    public function testReadinessReturns200WhenDegraded(): void
+    {
+        $service = $this->createMock(HealthCheckService::class);
+        $service->method('runAllChecks')->willReturn([
+            'status' => 'degraded',
+            'timestamp' => '2024-01-01T00:00:00+00:00',
+            'duration' => 0.123,
+            'checks' => [],
+        ]);
+
+        $controller = new HealthCheckController($service);
+        $response = $controller->readiness(new Request());
+
+        $this->assertEquals(200, $response->getStatusCode());
+    }
+
+    /**
+     * An unrecognised status must fail closed rather than be treated as healthy.
+     */
+    public function testUnknownStatusFallsBackTo503(): void
+    {
+        $service = $this->createMock(HealthCheckService::class);
+        $service->method('runAllChecks')->willReturn([
+            'status' => 'bogus',
+            'timestamp' => '2024-01-01T00:00:00+00:00',
+            'duration' => 0.123,
+            'checks' => [],
+        ]);
+
+        $controller = new HealthCheckController($service);
+        $response = $controller->check(new Request());
+
+        $this->assertEquals(503, $response->getStatusCode());
+    }
+
+    /**
+     * A malformed probe URL (?group[]=web) must not make the endpoint itself
+     * fail; the filter is simply ignored.
+     */
+    public function testArrayShapedGroupParameterIsIgnored(): void
+    {
+        $service = $this->createMock(HealthCheckService::class);
+        $service->expects($this->once())
+            ->method('runAllChecks')
+            ->with(null)
+            ->willReturn([
+                'status' => 'healthy',
+                'timestamp' => '2024-01-01T00:00:00+00:00',
+                'duration' => 0.123,
+                'checks' => [],
+            ]);
+
+        $controller = new HealthCheckController($service);
+        $response = $controller->check(new Request(['group' => ['web', 'worker']]));
+
+        $this->assertEquals(200, $response->getStatusCode());
+    }
+
+    public function testEmptyGroupParameterIsTreatedAsNoFilter(): void
+    {
+        $service = $this->createMock(HealthCheckService::class);
+        $service->expects($this->once())
+            ->method('runAllChecks')
+            ->with(null)
+            ->willReturn([
+                'status' => 'healthy',
+                'timestamp' => '2024-01-01T00:00:00+00:00',
+                'duration' => 0.123,
+                'checks' => [],
+            ]);
+
+        $controller = new HealthCheckController($service);
+        $controller->check(new Request(['group' => '']));
     }
 
     public function testReadinessReturnsValidJsonStructure(): void
@@ -296,7 +393,7 @@ class HealthCheckControllerTest extends TestCase
         $request = new Request();
         $response = $controller->readiness($request);
 
-        $data = json_decode($response->getContent(), true);
+        $data = json_decode((string) $response->getContent(), true);
         $this->assertIsArray($data);
         $this->assertArrayHasKey('status', $data);
         $this->assertArrayHasKey('timestamp', $data);

--- a/tests/Controller/PingControllerTest.php
+++ b/tests/Controller/PingControllerTest.php
@@ -27,7 +27,7 @@ class PingControllerTest extends TestCase
         $this->assertInstanceOf(JsonResponse::class, $response);
         $this->assertEquals(200, $response->getStatusCode());
 
-        $data = json_decode($response->getContent(), true);
+        $data = json_decode((string) $response->getContent(), true);
         $this->assertIsArray($data);
         $this->assertEquals('up', $data['status']);
         $this->assertArrayHasKey('timestamp', $data);
@@ -36,9 +36,11 @@ class PingControllerTest extends TestCase
     public function testPingReturnsValidTimestamp(): void
     {
         $response = $this->controller->ping();
-        $data = json_decode($response->getContent(), true);
+        $data = json_decode((string) $response->getContent(), true);
 
         // Verify timestamp is in RFC3339 format
+        $this->assertIsArray($data);
+        $this->assertIsString($data['timestamp']);
         $this->assertNotEmpty($data['timestamp']);
         $timestamp = \DateTimeImmutable::createFromFormat(\DateTimeInterface::RFC3339, $data['timestamp']);
         $this->assertInstanceOf(\DateTimeImmutable::class, $timestamp);

--- a/tests/DependencyInjection/Compiler/HealthCheckPassTest.php
+++ b/tests/DependencyInjection/Compiler/HealthCheckPassTest.php
@@ -1,0 +1,195 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kiora\HealthCheckBundle\Tests\DependencyInjection\Compiler;
+
+use Kiora\HealthCheckBundle\DependencyInjection\Compiler\HealthCheckPass;
+use Kiora\HealthCheckBundle\HealthCheck\AbstractHealthCheck;
+use Kiora\HealthCheckBundle\HealthCheck\Checks\DatabaseHealthCheck;
+use Kiora\HealthCheckBundle\HealthCheck\Checks\RedisHealthCheck;
+use Kiora\HealthCheckBundle\HealthCheck\HealthCheckResult;
+use Kiora\HealthCheckBundle\Service\HealthCheckService;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\DependencyInjection\Argument\IteratorArgument;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Reference;
+
+class HealthCheckPassTest extends TestCase
+{
+    /**
+     * The parameter is absent whenever the extension has not run; the pass must
+     * not blow up the container build over it.
+     */
+    public function testDoesNotFailWhenConfigParameterIsMissing(): void
+    {
+        $container = $this->containerWithService();
+        $container->setDefinition('app.custom_check', $this->taggedCheck(CustomCheck::class));
+
+        (new HealthCheckPass())->process($container);
+
+        $this->assertSame(['app.custom_check'], $this->injectedIds($container));
+    }
+
+    public function testDoesNothingWithoutTheHealthCheckService(): void
+    {
+        $container = new ContainerBuilder();
+
+        (new HealthCheckPass())->process($container);
+
+        $this->assertFalse($container->has(HealthCheckService::class));
+    }
+
+    /**
+     * Checks must stay lazily instantiated. A plain array of references would
+     * build every check — and open every connection they hold — up front.
+     */
+    public function testChecksAreInjectedAsALazyIterator(): void
+    {
+        $container = $this->containerWithService();
+        $container->setDefinition('app.custom_check', $this->taggedCheck(CustomCheck::class));
+
+        (new HealthCheckPass())->process($container);
+
+        $argument = $container->getDefinition(HealthCheckService::class)->getArgument('$healthChecks');
+
+        $this->assertInstanceOf(IteratorArgument::class, $argument);
+    }
+
+    public function testDisabledDatabaseCheckIsRemoved(): void
+    {
+        $container = $this->containerWithService([
+            'database' => ['enabled' => false],
+            'redis' => ['enabled' => false],
+        ]);
+        $container->setDefinition('app.database_check', $this->taggedCheck(DatabaseHealthCheck::class));
+
+        (new HealthCheckPass())->process($container);
+
+        $this->assertSame([], $this->injectedIds($container));
+        $this->assertFalse($container->hasDefinition('app.database_check'));
+    }
+
+    public function testEnabledRedisCheckIsInjected(): void
+    {
+        $container = $this->containerWithService(['redis' => ['enabled' => true]]);
+        $container->setDefinition('app.redis_check', $this->taggedCheck(RedisHealthCheck::class));
+
+        (new HealthCheckPass())->process($container);
+
+        $this->assertSame(['app.redis_check'], $this->injectedIds($container));
+    }
+
+    public function testRedisCheckIsDisabledByDefault(): void
+    {
+        $container = $this->containerWithService(['database' => ['enabled' => true]]);
+        $container->setDefinition('app.redis_check', $this->taggedCheck(RedisHealthCheck::class));
+
+        (new HealthCheckPass())->process($container);
+
+        $this->assertSame([], $this->injectedIds($container));
+    }
+
+    /**
+     * Enable/disable resolution keys off the service class, not its id.
+     *
+     * Matching on a substring of the id would disable any application service
+     * whose name merely contains "DatabaseHealthCheck".
+     */
+    public function testUnrelatedServiceNamedLikeABuiltInIsNotDisabled(): void
+    {
+        $container = $this->containerWithService(['database' => ['enabled' => false]]);
+        $container->setDefinition('app.my_DatabaseHealthCheck_wrapper', $this->taggedCheck(CustomCheck::class));
+
+        (new HealthCheckPass())->process($container);
+
+        $this->assertSame(['app.my_DatabaseHealthCheck_wrapper'], $this->injectedIds($container));
+        $this->assertTrue($container->hasDefinition('app.my_DatabaseHealthCheck_wrapper'));
+    }
+
+    public function testChecksAreOrderedByTagPriority(): void
+    {
+        $container = $this->containerWithService();
+
+        $low = $this->taggedCheck(CustomCheck::class, ['priority' => -10]);
+        $high = $this->taggedCheck(CustomCheck::class, ['priority' => 100]);
+        $default = $this->taggedCheck(CustomCheck::class);
+
+        $container->setDefinition('app.low', $low);
+        $container->setDefinition('app.high', $high);
+        $container->setDefinition('app.default', $default);
+
+        (new HealthCheckPass())->process($container);
+
+        $this->assertSame(['app.high', 'app.default', 'app.low'], $this->injectedIds($container));
+    }
+
+    /**
+     * @param array<string, mixed>|null $checksConfig
+     */
+    private function containerWithService(?array $checksConfig = null): ContainerBuilder
+    {
+        $container = new ContainerBuilder();
+        $container->setDefinition(HealthCheckService::class, new Definition(HealthCheckService::class));
+
+        if (null !== $checksConfig) {
+            $container->setParameter('health_check.checks', $checksConfig);
+        }
+
+        return $container;
+    }
+
+    /**
+     * @param array<string, mixed> $tagAttributes
+     */
+    private function taggedCheck(string $class, array $tagAttributes = []): Definition
+    {
+        $definition = new Definition($class);
+        $definition->addTag(HealthCheckPass::TAG_NAME, $tagAttributes);
+
+        return $definition;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function injectedIds(ContainerBuilder $container): array
+    {
+        $argument = $container->getDefinition(HealthCheckService::class)->getArgument('$healthChecks');
+
+        $references = $argument instanceof IteratorArgument ? $argument->getValues() : $argument;
+
+        $ids = [];
+
+        foreach ((array) $references as $reference) {
+            $this->assertInstanceOf(Reference::class, $reference);
+            $ids[] = (string) $reference;
+        }
+
+        return $ids;
+    }
+}
+
+class CustomCheck extends AbstractHealthCheck
+{
+    public function getName(): string
+    {
+        return 'custom';
+    }
+
+    public function getTimeout(): int
+    {
+        return 5;
+    }
+
+    public function isCritical(): bool
+    {
+        return false;
+    }
+
+    protected function doCheck(): HealthCheckResult
+    {
+        return $this->createHealthyResult('Custom check passed');
+    }
+}

--- a/tests/HealthCheck/AbstractHealthCheckResilienceTest.php
+++ b/tests/HealthCheck/AbstractHealthCheckResilienceTest.php
@@ -189,13 +189,19 @@ class RecordingLogger extends AbstractLogger
     public array $records = [];
 
     /**
+     * $message is deliberately left untyped: psr/log only narrowed it to
+     * string|\Stringable in 3.0, and this bundle supports ^1.0|^2.0|^3.0.
+     * Widening a parameter stays compatible with all three.
+     *
+     * @param mixed                $level
+     * @param mixed                $message
      * @param array<string, mixed> $context
      */
-    public function log($level, \Stringable|string $message, array $context = []): void
+    public function log($level, $message, array $context = []): void
     {
         $this->records[] = [
             'level' => is_string($level) ? $level : (string) json_encode($level),
-            'message' => (string) $message,
+            'message' => $message instanceof \Stringable || is_scalar($message) ? (string) $message : '',
             'context' => $context,
         ];
     }

--- a/tests/HealthCheck/AbstractHealthCheckResilienceTest.php
+++ b/tests/HealthCheck/AbstractHealthCheckResilienceTest.php
@@ -1,0 +1,202 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kiora\HealthCheckBundle\Tests\HealthCheck;
+
+use Kiora\HealthCheckBundle\HealthCheck\AbstractHealthCheck;
+use Kiora\HealthCheckBundle\HealthCheck\HealthCheckResult;
+use Kiora\HealthCheckBundle\HealthCheck\HealthCheckStatus;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\AbstractLogger;
+use Psr\Log\LoggerAwareInterface;
+
+/**
+ * Covers the failure handling added to AbstractHealthCheck: exception capture,
+ * internal logging, and timeout overrun reporting.
+ */
+class AbstractHealthCheckResilienceTest extends TestCase
+{
+    public function testThrownExceptionBecomesUnhealthyResult(): void
+    {
+        $check = new ThrowingHealthCheck(new \RuntimeException('connection refused to db-01:5432'));
+
+        $result = $check->check();
+
+        $this->assertSame(HealthCheckStatus::UNHEALTHY, $result->status);
+        $this->assertSame('Health check failed', $result->message);
+    }
+
+    public function testErrorsAreCaughtNotJustExceptions(): void
+    {
+        $check = new ThrowingHealthCheck(new \Error('Class "Redis" not found'));
+
+        $this->assertSame(HealthCheckStatus::UNHEALTHY, $check->check()->status);
+    }
+
+    /**
+     * The response must not leak internal detail, but the operator needs it:
+     * the exception goes to the log, never to the payload.
+     */
+    public function testFailureDetailGoesToTheLoggerAndNotThePayload(): void
+    {
+        $exception = new \RuntimeException('connection refused to db-01:5432');
+        $logger = new RecordingLogger();
+
+        $check = new ThrowingHealthCheck($exception);
+        $check->setLogger($logger);
+
+        $result = $check->check();
+
+        $this->assertStringNotContainsString('db-01', $result->message);
+        $this->assertSame([], $result->metadata);
+
+        $this->assertCount(1, $logger->records);
+        $this->assertSame('error', $logger->records[0]['level']);
+        $this->assertSame($exception, $logger->records[0]['context']['exception']);
+        $this->assertSame('throwing', $logger->records[0]['context']['check']);
+    }
+
+    public function testCheckIsLoggerAware(): void
+    {
+        $this->assertInstanceOf(LoggerAwareInterface::class, new ThrowingHealthCheck(new \Error('x')));
+    }
+
+    public function testWorksWithoutALogger(): void
+    {
+        // No logger injected: the check must still degrade gracefully.
+        $result = (new ThrowingHealthCheck(new \RuntimeException('boom')))->check();
+
+        $this->assertSame(HealthCheckStatus::UNHEALTHY, $result->status);
+    }
+
+    /**
+     * set_time_limit() cannot interrupt blocking I/O, so an overrun is detected
+     * after the fact and surfaced instead of passing as healthy.
+     */
+    public function testOverrunningCheckIsReportedAsDegraded(): void
+    {
+        $logger = new RecordingLogger();
+        $check = new SlowHealthCheck(timeout: 1, sleepSeconds: 1.1);
+        $check->setLogger($logger);
+
+        $result = $check->check();
+
+        $this->assertSame(HealthCheckStatus::DEGRADED, $result->status);
+        $this->assertStringContainsString('exceeded timeout', $result->message);
+        $this->assertCount(1, $logger->records);
+        $this->assertSame('warning', $logger->records[0]['level']);
+    }
+
+    public function testCheckWithinItsTimeoutStaysHealthy(): void
+    {
+        $result = (new SlowHealthCheck(timeout: 5, sleepSeconds: 0.0))->check();
+
+        $this->assertSame(HealthCheckStatus::HEALTHY, $result->status);
+        $this->assertStringNotContainsString('exceeded timeout', $result->message);
+    }
+
+    /**
+     * An overrun must not upgrade an already-failing check to degraded, which
+     * would turn a 503 into a 200.
+     */
+    public function testOverrunDoesNotMaskAnUnhealthyResult(): void
+    {
+        $check = new SlowHealthCheck(timeout: 1, sleepSeconds: 1.1, status: HealthCheckStatus::UNHEALTHY);
+
+        $this->assertSame(HealthCheckStatus::UNHEALTHY, $check->check()->status);
+    }
+
+    public function testDurationIsMeasuredByTheBaseClass(): void
+    {
+        $result = (new SlowHealthCheck(timeout: 5, sleepSeconds: 0.05))->check();
+
+        $this->assertGreaterThan(0.0, $result->duration);
+    }
+}
+
+class ThrowingHealthCheck extends AbstractHealthCheck
+{
+    public function __construct(private readonly \Throwable $throwable)
+    {
+    }
+
+    public function getName(): string
+    {
+        return 'throwing';
+    }
+
+    public function getTimeout(): int
+    {
+        return 5;
+    }
+
+    public function isCritical(): bool
+    {
+        return true;
+    }
+
+    protected function doCheck(): HealthCheckResult
+    {
+        throw $this->throwable;
+    }
+}
+
+class SlowHealthCheck extends AbstractHealthCheck
+{
+    public function __construct(
+        private readonly int $timeout,
+        private readonly float $sleepSeconds,
+        private readonly HealthCheckStatus $status = HealthCheckStatus::HEALTHY
+    ) {
+    }
+
+    public function getName(): string
+    {
+        return 'slow';
+    }
+
+    public function getTimeout(): int
+    {
+        return $this->timeout;
+    }
+
+    public function isCritical(): bool
+    {
+        return false;
+    }
+
+    protected function doCheck(): HealthCheckResult
+    {
+        if ($this->sleepSeconds > 0.0) {
+            usleep((int) ($this->sleepSeconds * 1_000_000));
+        }
+
+        return HealthCheckStatus::UNHEALTHY === $this->status
+            ? $this->createUnhealthyResult('Slow check failed')
+            : $this->createHealthyResult('Slow check passed');
+    }
+}
+
+/**
+ * Minimal PSR-3 logger capturing what the checks report.
+ */
+class RecordingLogger extends AbstractLogger
+{
+    /**
+     * @var list<array{level: string, message: string, context: array<string, mixed>}>
+     */
+    public array $records = [];
+
+    /**
+     * @param array<string, mixed> $context
+     */
+    public function log($level, \Stringable|string $message, array $context = []): void
+    {
+        $this->records[] = [
+            'level' => is_string($level) ? $level : (string) json_encode($level),
+            'message' => (string) $message,
+            'context' => $context,
+        ];
+    }
+}

--- a/tests/HealthCheck/AbstractHealthCheckTest.php
+++ b/tests/HealthCheck/AbstractHealthCheckTest.php
@@ -133,16 +133,25 @@ class ConcreteHealthCheck extends AbstractHealthCheck
     }
 
     // Public wrapper methods to test protected factory methods
+    /**
+     * @param array<string, mixed> $metadata
+     */
     public function testCreateHealthyResult(string $message, array $metadata = []): HealthCheckResult
     {
         return $this->createHealthyResult($message, $metadata);
     }
 
+    /**
+     * @param array<string, mixed> $metadata
+     */
     public function testCreateUnhealthyResult(string $message, array $metadata = []): HealthCheckResult
     {
         return $this->createUnhealthyResult($message, $metadata);
     }
 
+    /**
+     * @param array<string, mixed> $metadata
+     */
     public function testCreateDegradedResult(string $message, array $metadata = []): HealthCheckResult
     {
         return $this->createDegradedResult($message, $metadata);

--- a/tests/HealthCheck/Checks/HttpHealthCheckTest.php
+++ b/tests/HealthCheck/Checks/HttpHealthCheckTest.php
@@ -1,0 +1,153 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kiora\HealthCheckBundle\Tests\HealthCheck\Checks;
+
+use Kiora\HealthCheckBundle\HealthCheck\Checks\HttpHealthCheck;
+use Kiora\HealthCheckBundle\HealthCheck\HealthCheckStatus;
+use PHPUnit\Framework\TestCase;
+use Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+class HttpHealthCheckTest extends TestCase
+{
+    public function testHealthyOnExpectedStatusCode(): void
+    {
+        $check = new HttpHealthCheck(
+            url: 'https://example.test/health',
+            httpClient: $this->clientReturning(200)
+        );
+
+        $result = $check->check();
+
+        $this->assertSame(HealthCheckStatus::HEALTHY, $result->status);
+        $this->assertSame('HTTP endpoint operational', $result->message);
+    }
+
+    public function testUnhealthyOnUnexpectedStatusCode(): void
+    {
+        $check = new HttpHealthCheck(
+            url: 'https://example.test/health',
+            httpClient: $this->clientReturning(500)
+        );
+
+        $result = $check->check();
+
+        $this->assertSame(HealthCheckStatus::UNHEALTHY, $result->status);
+        $this->assertSame('HTTP endpoint returned unexpected status', $result->message);
+    }
+
+    public function testCustomExpectedStatusCodesAreHonoured(): void
+    {
+        $check = new HttpHealthCheck(
+            url: 'https://example.test/health',
+            expectedStatusCodes: [418],
+            httpClient: $this->clientReturning(418)
+        );
+
+        $this->assertSame(HealthCheckStatus::HEALTHY, $check->check()->status);
+    }
+
+    public function testUnhealthyWhenTransportFails(): void
+    {
+        $client = $this->createMock(HttpClientInterface::class);
+        $client->method('request')->willThrowException(
+            new class extends \RuntimeException implements TransportExceptionInterface {}
+        );
+
+        $check = new HttpHealthCheck(url: 'https://example.test/health', httpClient: $client);
+        $result = $check->check();
+
+        $this->assertSame(HealthCheckStatus::UNHEALTHY, $result->status);
+        $this->assertSame('HTTP endpoint unreachable', $result->message);
+        $this->assertSame([], $result->metadata);
+    }
+
+    /**
+     * The body must never be downloaded: only the status line matters, and a
+     * monitored endpoint may return an arbitrarily large payload.
+     */
+    public function testResponseBodyIsNeverRead(): void
+    {
+        $response = $this->createMock(ResponseInterface::class);
+        $response->method('getStatusCode')->willReturn(200);
+        $response->expects($this->never())->method('getContent');
+
+        $client = $this->createMock(HttpClientInterface::class);
+        $client->method('request')->willReturn($response);
+
+        $check = new HttpHealthCheck(url: 'https://example.test/health', httpClient: $client);
+
+        $this->assertSame(HealthCheckStatus::HEALTHY, $check->check()->status);
+    }
+
+    public function testTimeoutAndRedirectOptionsArePassedToTheClient(): void
+    {
+        $response = $this->createMock(ResponseInterface::class);
+        $response->method('getStatusCode')->willReturn(200);
+
+        $client = $this->createMock(HttpClientInterface::class);
+        $client->expects($this->once())
+            ->method('request')
+            ->with(
+                'GET',
+                'https://example.test/health',
+                $this->callback(static function (array $options): bool {
+                    return 2.0 === $options['timeout'] && 5 === $options['max_redirects'];
+                })
+            )
+            ->willReturn($response);
+
+        $check = new HttpHealthCheck(
+            url: 'https://example.test/health',
+            timeout: 2,
+            httpClient: $client,
+            maxRedirects: 5
+        );
+
+        $check->check();
+    }
+
+    public function testUnreachableHostWithoutHttpClient(): void
+    {
+        // Falls back to the stream wrapper; an unroutable address fails fast.
+        $check = new HttpHealthCheck(
+            url: 'http://127.0.0.1:1/health',
+            timeout: 1
+        );
+
+        $result = $check->check();
+
+        $this->assertSame(HealthCheckStatus::UNHEALTHY, $result->status);
+        $this->assertSame([], $result->metadata);
+    }
+
+    public function testAccessors(): void
+    {
+        $check = new HttpHealthCheck(
+            url: 'https://example.test/health',
+            name: 'payments_api',
+            timeout: 7,
+            critical: true,
+            groups: ['web']
+        );
+
+        $this->assertSame('payments_api', $check->getName());
+        $this->assertSame(7, $check->getTimeout());
+        $this->assertTrue($check->isCritical());
+        $this->assertSame(['web'], $check->getGroups());
+    }
+
+    private function clientReturning(int $statusCode): HttpClientInterface
+    {
+        $response = $this->createMock(ResponseInterface::class);
+        $response->method('getStatusCode')->willReturn($statusCode);
+
+        $client = $this->createMock(HttpClientInterface::class);
+        $client->method('request')->willReturn($response);
+
+        return $client;
+    }
+}

--- a/tests/HealthCheck/Checks/RedisHealthCheckTest.php
+++ b/tests/HealthCheck/Checks/RedisHealthCheckTest.php
@@ -58,7 +58,8 @@ class RedisHealthCheckTest extends TestCase
             $this->markTestSkipped('Redis extension not available');
         }
 
-        $check = new RedisHealthCheck();
+        $host = getenv('REDIS_HOST') ?: 'localhost';
+        $check = new RedisHealthCheck(host: $host);
         $result = $check->check();
 
         $this->assertSame(HealthCheckStatus::HEALTHY, $result->status);
@@ -99,7 +100,8 @@ class RedisHealthCheckTest extends TestCase
             $this->markTestSkipped('Redis extension not available');
         }
 
-        $check = new RedisHealthCheck();
+        $host = getenv('REDIS_HOST') ?: 'localhost';
+        $check = new RedisHealthCheck(host: $host);
 
         // First check should create connection
         $result1 = $check->check();
@@ -135,7 +137,8 @@ class RedisHealthCheckTest extends TestCase
         $this->assertSame(HealthCheckStatus::UNHEALTHY, $result1->status);
 
         // Create a new check with valid settings to test recovery
-        $checkRecovered = new RedisHealthCheck();
+        $host = getenv('REDIS_HOST') ?: 'localhost';
+        $checkRecovered = new RedisHealthCheck(host: $host);
         $result2 = $checkRecovered->check();
 
         // Should successfully connect with valid settings
@@ -149,8 +152,9 @@ class RedisHealthCheckTest extends TestCase
             $this->markTestSkipped('Redis extension not available');
         }
 
-        $check1 = new RedisHealthCheck(critical: true);
-        $check2 = new RedisHealthCheck(critical: false);
+        $host = getenv('REDIS_HOST') ?: 'localhost';
+        $check1 = new RedisHealthCheck(host: $host, critical: true);
+        $check2 = new RedisHealthCheck(host: $host, critical: false);
 
         $result1 = $check1->check();
         $result2 = $check2->check();
@@ -170,7 +174,8 @@ class RedisHealthCheckTest extends TestCase
             $this->markTestSkipped('Redis extension not available');
         }
 
-        $check = new RedisHealthCheck();
+        $host = getenv('REDIS_HOST') ?: 'localhost';
+        $check = new RedisHealthCheck(host: $host);
 
         // Perform multiple checks to verify persistent connection works
         for ($i = 0; $i < 5; ++$i) {
@@ -186,7 +191,8 @@ class RedisHealthCheckTest extends TestCase
             $this->markTestSkipped('Redis extension not available');
         }
 
-        $check = new RedisHealthCheck(host: 'localhost', port: 6379);
+        $host = getenv('REDIS_HOST') ?: 'localhost';
+        $check = new RedisHealthCheck(host: $host, port: 6379);
 
         $this->assertSame('redis', $check->getName());
 

--- a/tests/HealthCheck/Checks/S3HealthCheckTest.php
+++ b/tests/HealthCheck/Checks/S3HealthCheckTest.php
@@ -1,0 +1,128 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kiora\HealthCheckBundle\Tests\HealthCheck\Checks;
+
+use Kiora\HealthCheckBundle\HealthCheck\Checks\S3HealthCheck;
+use Kiora\HealthCheckBundle\HealthCheck\HealthCheckStatus;
+use League\Flysystem\DirectoryListing;
+use League\Flysystem\FilesystemException;
+use League\Flysystem\FilesystemOperator;
+use League\Flysystem\StorageAttributes;
+use PHPUnit\Framework\TestCase;
+
+class S3HealthCheckTest extends TestCase
+{
+    public function testHealthyWhenBucketIsListable(): void
+    {
+        $filesystem = $this->createMock(FilesystemOperator::class);
+        $filesystem->method('listContents')->willReturn(
+            new DirectoryListing($this->attributes(3))
+        );
+
+        $result = (new S3HealthCheck($filesystem))->check();
+
+        $this->assertSame(HealthCheckStatus::HEALTHY, $result->status);
+        $this->assertSame('S3 storage operational', $result->message);
+    }
+
+    public function testHealthyWhenBucketIsEmpty(): void
+    {
+        $filesystem = $this->createMock(FilesystemOperator::class);
+        $filesystem->method('listContents')->willReturn(new DirectoryListing([]));
+
+        $result = (new S3HealthCheck($filesystem))->check();
+
+        $this->assertSame(HealthCheckStatus::HEALTHY, $result->status);
+    }
+
+    /**
+     * The listing must be consumed lazily.
+     *
+     * Calling toArray() on a bucket holding millions of objects pages through
+     * every one of them, so a probe meant to be cheap becomes an incident of
+     * its own. Only the first entry may ever be pulled.
+     */
+    public function testStopsAfterFirstEntryOnLargeBucket(): void
+    {
+        // Bounded rather than infinite so a regression fails the assertion
+        // instead of hanging the suite.
+        $produced = 0;
+        $generator = (function () use (&$produced): \Generator {
+            for ($i = 0; $i < 1000; ++$i) {
+                ++$produced;
+
+                yield $this->attribute('file-'.$i.'.txt');
+            }
+        })();
+
+        $filesystem = $this->createMock(FilesystemOperator::class);
+        $filesystem->method('listContents')->willReturn(new DirectoryListing($generator));
+
+        $result = (new S3HealthCheck($filesystem))->check();
+
+        $this->assertSame(HealthCheckStatus::HEALTHY, $result->status);
+        $this->assertSame(1, $produced, 'The check must not walk the whole bucket');
+    }
+
+    public function testUnhealthyWhenFilesystemThrows(): void
+    {
+        $filesystem = $this->createMock(FilesystemOperator::class);
+        $filesystem->method('listContents')->willThrowException(
+            new class extends \RuntimeException implements FilesystemException {}
+        );
+
+        $result = (new S3HealthCheck($filesystem))->check();
+
+        $this->assertSame(HealthCheckStatus::UNHEALTHY, $result->status);
+        $this->assertSame('S3 storage connection failed', $result->message);
+        $this->assertSame([], $result->metadata);
+    }
+
+    public function testUnhealthyWhenFilesystemRaisesAnError(): void
+    {
+        $filesystem = $this->createMock(FilesystemOperator::class);
+        $filesystem->method('listContents')->willThrowException(new \Error('driver blew up'));
+
+        $result = (new S3HealthCheck($filesystem))->check();
+
+        $this->assertSame(HealthCheckStatus::UNHEALTHY, $result->status);
+    }
+
+    public function testMetadataAndNaming(): void
+    {
+        $filesystem = $this->createMock(FilesystemOperator::class);
+        $filesystem->method('listContents')->willReturn(new DirectoryListing([]));
+
+        $default = new S3HealthCheck($filesystem);
+        $named = new S3HealthCheck($filesystem, 'backups', true, ['worker']);
+
+        $this->assertSame('s3', $default->getName());
+        $this->assertFalse($default->isCritical());
+        $this->assertSame([], $default->getGroups());
+
+        $this->assertSame('backups', $named->getName());
+        $this->assertTrue($named->isCritical());
+        $this->assertSame(['worker'], $named->getGroups());
+    }
+
+    /**
+     * @return list<StorageAttributes>
+     */
+    private function attributes(int $count): array
+    {
+        $items = [];
+
+        for ($i = 0; $i < $count; ++$i) {
+            $items[] = $this->attribute('file-'.$i.'.txt');
+        }
+
+        return $items;
+    }
+
+    private function attribute(string $path): StorageAttributes
+    {
+        return new \League\Flysystem\FileAttributes($path);
+    }
+}

--- a/tests/Service/HealthCheckServiceTest.php
+++ b/tests/Service/HealthCheckServiceTest.php
@@ -114,7 +114,7 @@ class HealthCheckServiceTest extends TestCase
         $this->assertSame('unhealthy', $results['status']);
     }
 
-    public function testOverallStatusIsHealthyWhenNonCriticalCheckFails(): void
+    public function testOverallStatusIsDegradedWhenNonCriticalCheckFails(): void
     {
         $check1 = $this->createMockCheck('check1', [], HealthCheckStatus::HEALTHY, true);
         $check2 = $this->createMockCheck('check2', [], HealthCheckStatus::UNHEALTHY, false); // Non-critical
@@ -122,7 +122,32 @@ class HealthCheckServiceTest extends TestCase
         $service = new HealthCheckService([$check1, $check2]);
         $results = $service->runAllChecks();
 
-        $this->assertSame('healthy', $results['status']); // Still healthy because failed check is non-critical
+        // Degraded, not unhealthy: the failure is reported to monitoring but
+        // still maps to HTTP 200, so the instance keeps serving traffic.
+        $this->assertSame('degraded', $results['status']);
+        $this->assertSame(200, HealthCheckStatus::from($results['status'])->getHttpStatusCode());
+    }
+
+    public function testOverallStatusIsDegradedWhenACheckReportsDegraded(): void
+    {
+        $check1 = $this->createMockCheck('check1', [], HealthCheckStatus::HEALTHY, true);
+        $check2 = $this->createMockCheck('check2', [], HealthCheckStatus::DEGRADED, true);
+
+        $service = new HealthCheckService([$check1, $check2]);
+        $results = $service->runAllChecks();
+
+        $this->assertSame('degraded', $results['status']);
+    }
+
+    public function testCriticalFailureOutweighsDegradedChecks(): void
+    {
+        $check1 = $this->createMockCheck('check1', [], HealthCheckStatus::DEGRADED, false);
+        $check2 = $this->createMockCheck('check2', [], HealthCheckStatus::UNHEALTHY, true);
+
+        $service = new HealthCheckService([$check1, $check2]);
+        $results = $service->runAllChecks();
+
+        $this->assertSame('unhealthy', $results['status']);
     }
 
     public function testCacheHitPreventsDoubleExecution(): void
@@ -449,6 +474,7 @@ class HealthCheckServiceTest extends TestCase
         $this->assertSame(2, $results['statistics']['total_checks']);
         $this->assertSame(0, $results['statistics']['slow_checks']);
         $this->assertSame(0.2, $results['statistics']['average_duration']); // (0.1 + 0.3) / 2
+        $this->assertNotNull($results['statistics']['slowest_check']);
         $this->assertSame('all_groups_check', $results['statistics']['slowest_check']['name']);
         $this->assertSame(0.3, $results['statistics']['slowest_check']['duration']);
     }
@@ -464,6 +490,7 @@ class HealthCheckServiceTest extends TestCase
 
         // Average: (0.1234567 + 0.9876543) / 2 = 0.5555555 => rounded to 0.556
         $this->assertSame(0.556, $results['statistics']['average_duration']);
+        $this->assertNotNull($results['statistics']['slowest_check']);
         $this->assertSame(0.988, $results['statistics']['slowest_check']['duration']);
     }
 
@@ -477,10 +504,105 @@ class HealthCheckServiceTest extends TestCase
         $this->assertSame(1, $results['statistics']['total_checks']);
         $this->assertSame(0, $results['statistics']['slow_checks']);
         $this->assertSame(0.42, $results['statistics']['average_duration']);
+        $this->assertNotNull($results['statistics']['slowest_check']);
         $this->assertSame('single_check', $results['statistics']['slowest_check']['name']);
         $this->assertSame(0.42, $results['statistics']['slowest_check']['duration']);
     }
 
+    /**
+     * A group filter must not shift criticality onto the wrong check.
+     *
+     * Correlating results back to checks by array position silently breaks
+     * here: filtering drops the first check, so the failing non-critical one
+     * lands at index 0 and inherits the criticality of the check that was
+     * skipped — reporting a full outage where there is none.
+     */
+    public function testGroupFilterDoesNotMisattributeCriticality(): void
+    {
+        $skipped = $this->createMockCheck('skipped', ['worker'], HealthCheckStatus::HEALTHY, true);
+        $failing = $this->createMockCheck('failing', ['web'], HealthCheckStatus::UNHEALTHY, false);
+
+        $service = new HealthCheckService([$skipped, $failing]);
+        $results = $service->runAllChecks('web');
+
+        $this->assertCount(1, $results['checks']);
+        $this->assertSame('degraded', $results['status']);
+    }
+
+    /**
+     * The mirror case: a filtered-in critical failure must still be reported.
+     */
+    public function testGroupFilterKeepsCriticalFailureVisible(): void
+    {
+        $skipped = $this->createMockCheck('skipped', ['worker'], HealthCheckStatus::HEALTHY, false);
+        $failing = $this->createMockCheck('failing', ['web'], HealthCheckStatus::UNHEALTHY, true);
+
+        $service = new HealthCheckService([$skipped, $failing]);
+        $results = $service->runAllChecks('web');
+
+        $this->assertCount(1, $results['checks']);
+        $this->assertSame('unhealthy', $results['status']);
+    }
+
+    /**
+     * A cached unfiltered run must not be served to a filtered one.
+     */
+    public function testCacheIsScopedPerGroup(): void
+    {
+        $webOnly = $this->createMockCheck('web_only', ['web'], HealthCheckStatus::HEALTHY, true);
+        $workerOnly = $this->createMockCheck('worker_only', ['worker'], HealthCheckStatus::HEALTHY, true);
+
+        $service = new HealthCheckService([$webOnly, $workerOnly]);
+
+        $this->assertCount(2, $service->runAllChecks()['checks']);
+        $this->assertCount(1, $service->runAllChecks('web')['checks']);
+        $this->assertCount(1, $service->runAllChecks('worker')['checks']);
+    }
+
+    public function testGetHealthStatusReflectsCriticalityAndGroup(): void
+    {
+        $failing = $this->createMockCheck('failing', ['web'], HealthCheckStatus::UNHEALTHY, true);
+        $healthy = $this->createMockCheck('healthy', ['worker'], HealthCheckStatus::HEALTHY, true);
+
+        $service = new HealthCheckService([$failing, $healthy]);
+
+        $this->assertSame(HealthCheckStatus::UNHEALTHY, $service->getHealthStatus(group: 'web'));
+        $this->assertSame(HealthCheckStatus::HEALTHY, $service->getHealthStatus(group: 'worker'));
+    }
+
+    /**
+     * getHealthStatus() must reuse the cache instead of re-running every check.
+     */
+    public function testGetHealthStatusReusesCachedRun(): void
+    {
+        $callCount = 0;
+        $check = $this->createMock(HealthCheckInterface::class);
+        $check->method('getName')->willReturn('counted');
+        $check->method('getGroups')->willReturn([]);
+        $check->method('isCritical')->willReturn(true);
+        $check->method('getTimeout')->willReturn(5);
+        $check->method('check')->willReturnCallback(function () use (&$callCount): HealthCheckResult {
+            ++$callCount;
+
+            return new HealthCheckResult(
+                name: 'counted',
+                status: HealthCheckStatus::HEALTHY,
+                message: 'Test message',
+                duration: 0.0,
+                metadata: []
+            );
+        });
+
+        $service = new HealthCheckService([$check]);
+        $service->runAllChecks();
+        $service->getHealthStatus();
+
+        $this->assertSame(1, $callCount);
+    }
+
+    /**
+     * @param string[] $groups
+     */
     private function createMockCheck(
         string $name,
         array $groups,
@@ -505,6 +627,9 @@ class HealthCheckServiceTest extends TestCase
         return $check;
     }
 
+    /**
+     * @param string[] $groups
+     */
     private function createMockCheckWithDuration(
         string $name,
         array $groups,


### PR DESCRIPTION
## Summary

Fixes a set of real defects found while auditing the bundle, plus the
robustness work around them. All changes are backwards compatible: no public
signature was removed or narrowed, only optional parameters added.

## The main bug

`HealthCheckService` correlated results back to checks **by array position**.
That correlation breaks as soon as a group filter skips a check — the remaining
results shift down and inherit the criticality of checks that were never run.

Both failure modes were reproduced against the previous implementation by
stashing the fix and running the new regression tests:

| Situation | Before | After |
|---|---|---|
| Non-critical check fails, group filter active | `unhealthy` → **HTTP 503** | `degraded` → HTTP 200 |
| Critical check fails, group filter active | `healthy` → **HTTP 200** | `unhealthy` → HTTP 503 |

So a dependency explicitly marked optional could take an instance out of
rotation, and a genuine outage could stay invisible to the load balancer.

## Other defects fixed

- **`/ping` and `/ready` were unreachable.** The README documents importing
  `@HealthCheckBundle/config/routes.php`, but that file only declared
  `/health`, and `PingController` was never registered as a service.
- **`S3HealthCheck` loaded the entire bucket into memory.** It called
  `toArray()` on the listing; the comment claimed "limit to 1" but nothing
  limited it. A probe meant to be cheap became an incident of its own.
- **`DatabaseHealthCheck` reported healthy Oracle/DB2 databases as down.** A
  bare `SELECT 1` is a syntax error on platforms requiring a `FROM` clause.
- **`HealthCheckPass`** read a container parameter without checking it exists
  (fatal when the extension had not run), matched built-in checks by substring
  of the service id (silently removing unrelated application services), and
  replaced the `tagged_iterator` with a plain array, discarding lazy
  instantiation so every check and its connections were built up front.
- **The pre-commit hook was broken.** GrumPHP ran PHPStan without a memory
  limit, crashing the worker at the 128M default on every commit.

## Behaviour change to be aware of

The overall status can now be **`degraded`** — it was previously documented as
"reserved for future use" and never emitted. A degraded check, or a
non-critical failure, now surfaces instead of being reported as `healthy`.

**`degraded` maps to HTTP 200**, so the HTTP contract is unchanged; the payload
simply stops hiding the condition. One existing test encoded the old behaviour
and was updated.

## Robustness added

- **Optional PSR-3 logging.** Responses stay generic by design, which left
  operators with `"Health check failed"` and no way to diagnose it. The real
  exception is now logged server-side and never reaches the payload.
- **Timeout overruns are detected.** `set_time_limit()` cannot interrupt
  blocking I/O, so the declared timeout was never actually enforced. Overruns
  are measured after the fact and reported as degraded.
- `HttpHealthCheck` accepts a Symfony HTTP client; the fallback no longer
  downloads the response body and understands HTTP/2 status lines.
- `RedisHealthCheck` accepts a pre-configured client.

## Verification

| | Before | After |
|---|---|---|
| Tests | 76 | **119**, 0 skipped |
| PHPStan level 9 | `src` | **`src` + `tests`** |
| GrumPHP | crashed | **passes** |

The CI matrix tested Symfony 6.4/7.0/7.1 while `composer.json` declares
`^6.4|^7.0|^8.0`, leaving the supported 8.x range unverified. It now covers
6.4/7.4/8.1 across PHP 8.3–8.5, plus a `--prefer-lowest` run.

## Review notes

Commits are thematic and individually testable — `e7dc687` is the one worth the
closest look. Local dependencies were refreshed along the way (Symfony 8.1,
PHPUnit 12): Composer 2.9 refused to install because the locked versions
carried known advisories. `composer.lock` is gitignored, so this affects only
local environments; `composer audit` is now clean.
